### PR TITLE
ec2: add list_keys method

### DIFF
--- a/pycloudlib/cloud.py
+++ b/pycloudlib/cloud.py
@@ -117,6 +117,15 @@ class BaseCloud:
         """
         raise NotImplementedError
 
+    def list_keys(self):
+        """List ssh key names present on the cloud for accessing instances.
+
+        Returns:
+           A list of strings of key pair names accessible to the cloud.
+
+        """
+        raise NotImplementedError
+
     def use_key(self, public_key_path, private_key_path=None, name=None):
         """Use an existing key.
 

--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -194,6 +194,7 @@ class EC2(BaseCloud):
         return instance
 
     def list_keys(self):
+        """List all ssh key pair names loaded on this EC2 region."""
         keypair_names = []
         for keypair in self.client.describe_key_pairs()["KeyPairs"]:
             keypair_names.append(keypair["KeyName"])

--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -193,6 +193,12 @@ class EC2(BaseCloud):
 
         return instance
 
+    def list_keys(self):
+        keypair_names = []
+        for keypair in self.client.describe_key_pairs()["KeyPairs"]:
+            keypair_names.append(keypair["KeyName"])
+        return keypair_names
+
     def snapshot(self, instance, clean=True):
         """Snapshot an instance and generate an image from it.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.14.20
 botocore==1.17.20
 google-api-python-client==1.7.7
-paramiko==2.6.0
+paramiko==2.7.1
 pyyaml==5.1
 requests==2.22
 


### PR DESCRIPTION
Add ec2.list_keys operation to allow for checking if keys exist.

It allows us to look before we leap before calling either delete_key
or upload_key.