### PR TITLE
ec2: use pre-existng vpc if available when create_vpc is called

### DIFF
--- a/docs/clouds/ec2.md
+++ b/docs/clouds/ec2.md
@@ -59,7 +59,7 @@ Launching an instance requires at a minimum an AMI ID. Optionally, a user can sp
 ```python
 inst_0 = ec2.launch('ami-537e9a30')
 inst_1 = ec2.launch('ami-537e9a30', instance_type='i3.metal', user_data=data)
-vpc = ec2.create_vpc('private_vpc')
+vpc = ec2.get_or_create_vpc('private_vpc')
 inst_2 = ec2.launch('ami-537e9a30', vpc=vpc)
 ```
 
@@ -140,7 +140,7 @@ If a custom VPC is required for any reason, then one can be created
 and then later used during instance creation.
 
 ```python
-vpc = ec2.create_vpc(name, ipv4_cidr='192.168.1.0/20')
+vpc = ec2.get_or_create_vpc(name, ipv4_cidr='192.168.1.0/20')
 ec2.launch('ami-537e9a30', vpc=vpc)
 ```
 

--- a/examples/ec2.py
+++ b/examples/ec2.py
@@ -60,10 +60,10 @@ def snapshot(ec2, daily):
 
 def custom_vpc(ec2, daily):
     """Launch instances using a custom VPC."""
-    vpc = ec2.create_vpc('test-vpc')
-    instance = ec2.launch(daily, vpc=vpc)
+    vpc = ec2.get_or_create_vpc(name='test-vpc')
+    ec2.launch(daily, vpc=vpc)
 
-    instance.delete()
+    # vpc.delete will also delete any associated instances in that VPC
     vpc.delete()
 
 

--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -187,7 +187,13 @@ class EC2(BaseCloud):
             args[key] = value
 
         if vpc:
-            [subnet_id] = [s.id for s in vpc.vpc.subnets.all()]
+            try:
+                [subnet_id] = [s.id for s in vpc.vpc.subnets.all()]
+            except ValueError:
+                raise RuntimeError(
+                    "Too many subnets in vpc {}. pycloudlib does not support"
+                    " launching into VPCs with multiple subnets".format(vpc.id)
+                )
             args['SubnetId'] = subnet_id
             args['SecurityGroupIds'] = [
                 sg.id for sg in vpc.vpc.security_groups.all()

--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -43,7 +43,7 @@ class EC2(BaseCloud):
             raise RuntimeError(
                 'Please configure ec2 credentials in $HOME/.aws/credentials')
 
-    def create_vpc(self, name, ipv4_cidr='192.168.1.0/20'):
+    def get_or_create_vpc(self, name, ipv4_cidr='192.168.1.0/20'):
         """Create a or return matching VPC.
 
         This can be used instead of using the default VPC to create
@@ -62,8 +62,8 @@ class EC2(BaseCloud):
             Filters=[{'Name': 'tag:Name', 'Values': [name]}]
         )['Vpcs']
         if vpcs:
-            return VPC(self.resource, name=name, vpc_id=vpcs[0]['VpcId'])
-        return VPC(self.resource, name=name, ipv4_cidr=ipv4_cidr)
+            return VPC.from_existing(self.resource, vpc_id=vpcs[0]['VpcId'])
+        return VPC.create(self.resource, name=name, ipv4_cidr=ipv4_cidr)
 
     def released_image(self, release, arch='amd64', root_store='ssd'):
         """Find the id of the latest released image for a particular release.

--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -44,7 +44,7 @@ class EC2(BaseCloud):
                 'Please configure ec2 credentials in $HOME/.aws/credentials')
 
     def create_vpc(self, name, ipv4_cidr='192.168.1.0/20'):
-        """Create a custom VPC.
+        """Create a or return matching VPC.
 
         This can be used instead of using the default VPC to create
         a custom VPC for usage.
@@ -57,7 +57,13 @@ class EC2(BaseCloud):
             VPC object
 
         """
-        return VPC(self.resource, name, ipv4_cidr)
+        # Check to see if current VPC exists
+        vpcs = self.client.describe_vpcs(
+            Filters=[{'Name': 'tag:Name', 'Values': [name]}]
+        )['Vpcs']
+        if vpcs:
+            return VPC(self.resource, name=name, vpc_id=vpcs[0]['VpcId'])
+        return VPC(self.resource, name=name, ipv4_cidr=ipv4_cidr)
 
     def released_image(self, release, arch='amd64', root_store='ssd'):
         """Find the id of the latest released image for a particular release.
@@ -181,8 +187,11 @@ class EC2(BaseCloud):
             args[key] = value
 
         if vpc:
-            args['SecurityGroupIds'] = [vpc.security_group.id]
-            args['SubnetId'] = vpc.subnet.id
+            [subnet_id] = [s.id for s in vpc.vpc.subnets.all()]
+            args['SubnetId'] = subnet_id
+            args['SecurityGroupIds'] = [
+                sg.id for sg in vpc.vpc.security_groups.all()
+            ]
 
         self._log.debug('launching instance')
         instances = self.resource.create_instances(**args)

--- a/pycloudlib/ec2/vpc.py
+++ b/pycloudlib/ec2/vpc.py
@@ -15,7 +15,7 @@ class VPC:
     """Virtual Private Cloud class proxy for AWS VPC resource."""
 
     def __init__(self, vpc):
-        """Setup a VPC proxy instance for an AWS VPC resource.
+        """Create a VPC proxy instance for an AWS VPC resource.
 
         Args:
             vpc_id: Optional ID of existing VPC object to return
@@ -34,6 +34,7 @@ class VPC:
 
         Returns:
             pycloudlib.ec2.VPC instance
+
         """
         logger.debug('Creating VPC named (%s)', name)
         vpc = cls._create_vpc(
@@ -58,6 +59,7 @@ class VPC:
 
         Returns:
             pycloudlib.ec2.VPC instance
+
         """
         logger.debug('Reusing existing VPC (%s)', vpc_id)
         vpc = resource.Vpc(vpc_id)
@@ -131,7 +133,7 @@ class VPC:
 
     @classmethod
     def _create_subnet(cls, vpc, ipv4_cidr):
-        """Generate IPv4 and IPv6 subnets for use in an AWS VPC resource
+        """Generate IPv4 and IPv6 subnets for use in an AWS VPC resource.
 
         Args:
             vpc: AWS VPC resource to which the created subnet is associated.
@@ -169,7 +171,8 @@ class VPC:
             ipv4_cidr: CIDR for IPV4 network
 
         Returns:
-            Created VPC resource from AWS cli
+            VPC resource created from AWS cli
+
         """
         logger.debug(
             'creating new vpc named %s with subnet %s', name, ipv4_cidr

--- a/pycloudlib/ec2/vpc.py
+++ b/pycloudlib/ec2/vpc.py
@@ -8,62 +8,97 @@ from botocore.exceptions import ClientError
 from pycloudlib.ec2.util import _tag_resource
 
 
-class VPC:
-    """Virtual Private Cloud Class."""
+logger = logging.getLogger(__name__)
 
-    def __init__(self, resource, name, ipv4_cidr='192.168.1.0/20',
-                 vpc_id=None):
-        """Define and setup a VPC.
+
+class VPC:
+    """Virtual Private Cloud class proxy for AWS VPC resource."""
+
+    def __init__(self, vpc):
+        """Setup a VPC proxy instance for an AWS VPC resource.
 
         Args:
-            resource: EC2 resource object
-            name: name of VPC
-            ipv4_cidr: CIDR for IPV4 network
             vpc_id: Optional ID of existing VPC object to return
         """
-        self._log = logging.getLogger(__name__)
+        self.vpc = vpc
 
-        self.name = name
-        if vpc_id is not None:
-            self._log.debug(
-                'Reusing existing VPC (%s) named %s.', vpc_id, name
-            )
-            self.vpc = resource.Vpc(vpc_id)
-        else:
-            self._resource = resource
-            self.vpc = self._create_vpc(ipv4_cidr)
-            gateway = self._create_internet_gateway()
-            subnet = self._create_subnet(ipv4_cidr)
-            self._create_routing_table(gateway.id, subnet.id)
+    @classmethod
+    def create(cls, resource, name, ipv4_cidr='192.168.1.0/20'):
+        """Create a pycloudlib.ec2.VPC proxy for an AWS VPC resource.
+
+        Args:
+            resource: EC2 resource client
+            name: String for the name or tag of the VPC
+            ipv4_cidr: String of the CIDR for IPV4 subnet to associate with the
+                VPC.
+
+        Returns:
+            pycloudlib.ec2.VPC instance
+        """
+        logger.debug('Creating VPC named (%s)', name)
+        vpc = cls._create_vpc(
+            resource=resource, name=name, ipv4_cidr=ipv4_cidr
+        )
+        gateway = cls._create_internet_gateway(resource, vpc)
+        subnet = cls._create_subnet(vpc, ipv4_cidr)
+        route_table = cls._create_routing_table(vpc, gateway.id, subnet.id)
+        sec_group = cls._create_security_group(vpc, name)
+        for aws_resource in (vpc, gateway, subnet, route_table, sec_group):
+            _tag_resource(aws_resource, name)
+        logger.debug('Created VPC (%s) named (%s)', vpc.id, name)
+        return cls(vpc)
+
+    @classmethod
+    def from_existing(cls, resource, vpc_id):
+        """Wrap an existing boto3 EC2 VPC resource given the vpc_id.
+
+        Args:
+            resource: EC2 resource client
+            vpc_id: String for an existing VPC id.
+
+        Returns:
+            pycloudlib.ec2.VPC instance
+        """
+        logger.debug('Reusing existing VPC (%s)', vpc_id)
+        vpc = resource.Vpc(vpc_id)
+        return cls(vpc)
 
     @property
     def id(self):
         """ID of the VPC."""
         return self.vpc.id
 
-    def _create_internet_gateway(self):
+    @property
+    def name(self):
+        """Name of the VPC from tags."""
+        for tag in self.vpc.tags:
+            if tag["Key"] == "Name":
+                return tag["Value"]
+        return "NO-TAG-NAME-PRESENT"
+
+    @classmethod
+    def _create_internet_gateway(cls, resource, vpc):
         """Create Internet Gateway and assign to VPC.
 
         Returns:
             Internet gateway object
 
         """
-        self._log.debug('creating internet gateway')
-        internet_gateway = self._resource.create_internet_gateway()
-        internet_gateway.attach_to_vpc(VpcId=self.vpc.id)
-
-        _tag_resource(internet_gateway, self.name)
+        logger.debug('creating internet gateway for vpc %s', vpc.id)
+        internet_gateway = resource.create_internet_gateway()
+        internet_gateway.attach_to_vpc(VpcId=vpc.id)
 
         return internet_gateway
 
-    def _create_routing_table(self, gateway_id, subnet_id):
+    @classmethod
+    def _create_routing_table(cls, vpc, gateway_id, subnet_id):
         """Update default routing table with internet gateway and subnet.
 
         This sets up internet access between the VPC via the internet gateway
         by configuring routing tables for IPv4 and IPv6.
         """
-        self._log.debug('creating routing table')
-        route_table = self.vpc.create_route_table()
+        logger.debug('creating routing table')
+        route_table = vpc.create_route_table()
         route_table.create_route(
             DestinationCidrBlock='0.0.0.0/0',
             GatewayId=gateway_id
@@ -73,46 +108,46 @@ class VPC:
             GatewayId=gateway_id
         )
         route_table.associate_with_subnet(SubnetId=subnet_id)
+        return route_table
 
-        _tag_resource(route_table, self.name)
-
-    def _create_security_group(self):
+    @classmethod
+    def _create_security_group(cls, vpc, name):
         """Enable ingress to default VPC security group.
 
         Returns:
             Security group object
 
         """
-        self._log.debug('creating security group')
-        security_group = self.vpc.create_security_group(
-            GroupName=self.name,
+        logger.debug('creating security group')
+        security_group = vpc.create_security_group(
+            GroupName=name,
             Description='pycloudlib created security group'
         )
         security_group.authorize_ingress(
             IpProtocol='-1', FromPort=-1, ToPort=-1, CidrIp='0.0.0.0/0'
         )
 
-        _tag_resource(security_group, self.name)
-
         return security_group
 
-    def _create_subnet(self, ipv4_cidr):
-        """Generate IPv4 and IPv6 subnets for use.
+    @classmethod
+    def _create_subnet(cls, vpc, ipv4_cidr):
+        """Generate IPv4 and IPv6 subnets for use in an AWS VPC resource
 
         Args:
+            vpc: AWS VPC resource to which the created subnet is associated.
             ipv4_cidr: CIDR for IPV4 network
 
         Returns:
             Create subnet object
 
         """
-        ipv6_cidr = self.vpc.ipv6_cidr_block_association_set[0][
+        ipv6_cidr = vpc.ipv6_cidr_block_association_set[0][
             'Ipv6CidrBlock'][:-2] + '64'
 
-        self._log.debug('creating subnets with following ranges:')
-        self._log.debug('ipv4: %s', ipv4_cidr)
-        self._log.debug('ipv6: %s', ipv6_cidr)
-        subnet = self.vpc.create_subnet(
+        logger.debug('creating subnets with following ranges:')
+        logger.debug('ipv4: %s', ipv4_cidr)
+        logger.debug('ipv6: %s', ipv6_cidr)
+        subnet = vpc.create_subnet(
             CidrBlock=ipv4_cidr, Ipv6CidrBlock=ipv6_cidr
         )
 
@@ -122,23 +157,25 @@ class VPC:
             SubnetId=subnet.id, MapPublicIpOnLaunch={'Value': True}
         )
 
-        _tag_resource(subnet, self.name)
-
         return subnet
 
-    def _create_vpc(self, ipv4_cidr):
+    @classmethod
+    def _create_vpc(cls, resource, name, ipv4_cidr):
         """Set up AWS EC2 VPC or return existing VPC.
 
         Args:
+            resource: boto 3 resource client
+            name: the name/tag of the VPC to create
             ipv4_cidr: CIDR for IPV4 network
 
         Returns:
-            Create VPC object
-
+            Created VPC resource from AWS cli
         """
-        self._log.debug('creating new vpc named %s', self.name)
+        logger.debug(
+            'creating new vpc named %s with subnet %s', name, ipv4_cidr
+        )
         try:
-            vpc = self._resource.create_vpc(
+            vpc = resource.create_vpc(
                 CidrBlock=ipv4_cidr,
                 AmazonProvidedIpv6CidrBlock=True
             )
@@ -147,38 +184,36 @@ class VPC:
 
         vpc.wait_until_available()
 
-        _tag_resource(vpc, self.name)
-
         return vpc
 
     def delete(self):
-        """Terminate all instances and delete an entire VPC."""
+        """Terminate all associated instances and delete an entire VPC."""
         for instance in self.vpc.instances.all():
-            self._log.debug('waiting for instance %s termination', instance.id)
+            logger.debug('waiting for instance %s termination', instance.id)
             instance.terminate()
             instance.wait_until_terminated()
 
         for security_group in self.vpc.security_groups.all():
-            self._log.debug(
+            logger.debug(
                 'deleting security group %s', security_group.id
             )
             security_group.delete()
 
         for subnet in self.vpc.subnets.all():
-            self._log.debug('deleting subnet %s', subnet.id)
+            logger.debug('deleting subnet %s', subnet.id)
             subnet.delete()
 
         for route_table in self.vpc.route_tables.all():
-            self._log.debug('deleting routing table %s', route_table.id)
+            logger.debug('deleting routing table %s', route_table.id)
             route_table.delete()
 
         for gateway in self.vpc.internet_gateways.all():
-            self._log.debug(
+            logger.debug(
                 'deleting internet gateway %s', gateway.id
             )
             gateway.detach_from_vpc(VpcId=self.vpc.id)
             gateway.delete()
 
         if self.vpc:
-            self._log.debug('deleting vpc %s', self.vpc.id)
+            logger.debug('deleting vpc %s', self.vpc.id)
             self.vpc.delete()


### PR DESCRIPTION
Refactor ec2.create_vpc method to get_or_create_vpc which will reuse existing VPCs if present.

Refactor VPC class to better represent the proxy class that it is:
 * Add `VPC.create` method to create a new vpc providing a boto3 ec2.resource client, name/tag and optional ipv4_cidr
 * Add `VPC.from_existing` taking the same boto3 ec2.resource client and and the vpc_id of an existing EC2 VPC.
 * Simplify and decorate all @classmethods called by `VPC.create`
 * Add a `name` property method which looks up the 'Name' tag associated with the VPC to avoid carrying that instance attribute around.
 * `delete` now walks through all associated boto3 VPC resource properties and methods to perform deletion instead of relying on pycloudlib.ec2.VPC instance attributes for security groups, route tables, subnets etc.

The following pycloudlib.ec2.vpc.VPC attributes are no longer exposed:
  - cidr_ipv4, subnet, security_group, routing_table, internet_gateway.