### PR TITLE
Refactor api

### DIFF
--- a/examples/base_api.py
+++ b/examples/base_api.py
@@ -1,0 +1,86 @@
+"""A run through of base API operations on all supported clouds."""
+
+import os
+from contextlib import suppress
+
+import pycloudlib
+from pycloudlib.cloud import BaseCloud
+
+
+cloud_config = """#cloud-config
+runcmd:
+  - echo 'hello' > /home/ubuntu/example.txt
+"""
+
+
+def exercise_api(client: BaseCloud):
+    """Run through supported functions in the base API."""
+    try:
+        image_id = client.released_image('focal')
+    except NotImplementedError:
+        image_id = client.daily_image('focal')
+    print('focal image id: {}'.format(image_id))
+    print('launching instance...')
+    instance = client.launch(
+        image_id=image_id,
+        user_data=cloud_config
+    )
+    assert repr(instance) == repr(client.get_instance(instance.name))
+
+    print('instance name: {}'.format(instance.name))
+    with suppress(NotImplementedError):
+        print('instance ip: {}'.format(instance.ip))
+
+    print('starting instance...')
+    instance.start()
+    print('waiting for cloud-init...')
+    instance.execute('cloud-init status --wait --long')
+    with suppress(NotImplementedError):
+        instance.console_log()
+    assert instance.execute('cat /home/ubuntu/example.txt').stdout == 'hello'
+
+    print('restarting instance...')
+    instance.execute('sync')  # Prevent's some wtfs :)
+    instance.restart()
+    assert instance.execute('cat /home/ubuntu/example.txt').stdout == 'hello'
+
+    print('shutting down instance...')
+    instance.shutdown()
+    print('starting instance...')
+    instance.start()
+    print(instance.execute('cat /home/ubuntu/example.txt').stdout)
+    snapshot_id = None
+    with suppress(NotImplementedError):
+        print('snapshotting instance...')
+        snapshot_id = client.snapshot(instance)
+        print('snapshot image id: {}'.format(snapshot_id))
+    if snapshot_id:
+        assert snapshot_id != image_id
+        print('deleting snapshot...')
+        client.delete_image(snapshot_id)
+
+    print('deleting instance...')
+    instance.delete()
+
+
+clouds = {
+    pycloudlib.Azure: {},
+    pycloudlib.EC2: {},
+    # pycloudlib.GCE: {
+    #     'project': os.environ.get('PROJECT'),
+    #     'region': 'us-central1',
+    #     'zone': 'a',
+    # },
+    pycloudlib.OCI: {
+        'compartment_id': os.environ.get('COMPARTMENT_ID')
+    },
+    pycloudlib.KVM: {},
+    pycloudlib.LXD: {},
+}
+
+if __name__ == '__main__':
+    for cloud, kwargs in clouds.items():
+        print('Using cloud: {}'.format(cloud.__name__))
+        client_api = cloud(tag='base-api-test', **kwargs)
+        exercise_api(client_api)
+        print()

--- a/pycloudlib/azure/instance.py
+++ b/pycloudlib/azure/instance.py
@@ -143,3 +143,7 @@ class AzureInstance(BaseInstance):
     def wait(self):
         """Wait for instance to be up and cloud-init to be complete."""
         self._wait_for_system()
+
+    def console_log(self):
+        """Return the instance console log."""
+        raise NotImplementedError

--- a/pycloudlib/cloud.py
+++ b/pycloudlib/cloud.py
@@ -3,13 +3,14 @@
 
 import getpass
 import logging
+from abc import ABC, abstractmethod
 
 from pycloudlib.key import KeyPair
 from pycloudlib.streams import Streams
-from pycloudlib.util import get_timestamped_tag
+from pycloudlib.util import get_timestamped_tag, validate_tag
 
 
-class BaseCloud:
+class BaseCloud(ABC):
     """Base Cloud Class."""
 
     _type = 'base'
@@ -26,8 +27,9 @@ class BaseCloud:
         self.key_pair = KeyPair(
             '/home/%s/.ssh/id_rsa.pub' % _username, name=_username
         )
-        self.tag = get_timestamped_tag(tag)
+        self.tag = validate_tag(get_timestamped_tag(tag))
 
+    @abstractmethod
     def delete_image(self, image_id):
         """Delete an image.
 
@@ -36,7 +38,8 @@ class BaseCloud:
         """
         raise NotImplementedError
 
-    def released_image(self, release):
+    @abstractmethod
+    def released_image(self, release, **kwargs):
         """ID of the latest released image for a particular release.
 
         Args:
@@ -49,7 +52,8 @@ class BaseCloud:
         """
         raise NotImplementedError
 
-    def daily_image(self, release):
+    @abstractmethod
+    def daily_image(self, release, **kwargs):
         """ID of the latest daily image for a particular release.
 
         Args:
@@ -62,6 +66,7 @@ class BaseCloud:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def image_serial(self, image_id):
         """Find the image serial of the latest daily image for a particular release.
 
@@ -74,7 +79,8 @@ class BaseCloud:
         """
         raise NotImplementedError
 
-    def get_instance(self, instance_id):
+    @abstractmethod
+    def get_instance(self, instance_id):  # () -> BaseInstance
         """Get an instance by id.
 
         Args:
@@ -86,12 +92,15 @@ class BaseCloud:
         """
         raise NotImplementedError
 
-    def launch(self, instance_type, image_id, wait=False, **kwargs):
+    @abstractmethod
+    def launch(self, image_id, instance_type=None, user_data=None,
+               wait=True, **kwargs):  # () -> BaseInstance
         """Launch an instance.
 
         Args:
-            instance_type: string, type of instance to create
             image_id: string, image ID to use for the instance
+            instance_type: string, type of instance to create
+            user_data: used by cloud-init to run custom scripts/configuration
             wait: wait for instance to be live
             **kwargs: dictionary of other arguments to pass to launch
 
@@ -101,16 +110,16 @@ class BaseCloud:
         """
         raise NotImplementedError
 
-    def snapshot(self, instance_id, clean=True, wait=True):
+    @abstractmethod
+    def snapshot(self, instance, clean=True, **kwargs):
         """Snapshot an instance and generate an image from it.
 
         Args:
             instance: Instance to snapshot
             clean: run instance clean method before taking snapshot
-            wait: wait for instance to get created
 
         Returns:
-            An image object
+            An image id
 
         """
         raise NotImplementedError

--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -150,18 +150,18 @@ class EC2(BaseCloud):
 
         """
         instance = self.resource.Instance(instance_id)
-        return EC2Instance(self.client, self.key_pair, instance)
+        return EC2Instance(self.key_pair, self.client, instance)
 
     def launch(self, image_id, instance_type='t2.micro', user_data=None,
-               vpc=None, wait=True, **kwargs):
+               wait=True, vpc=None, **kwargs):
         """Launch instance on EC2.
 
         Args:
             image_id: string, AMI ID to use default: latest Ubuntu LTS
             instance_type: string, instance type to launch
             user_data: string, user-data to pass to instance
-            vpc: optional vpc object to create instance under
             wait: boolean, wait for instance to come up
+            vpc: optional vpc object to create instance under
             kwargs: other named arguments to add to instance JSON
 
         Returns:
@@ -201,7 +201,7 @@ class EC2(BaseCloud):
 
         self._log.debug('launching instance')
         instances = self.resource.create_instances(**args)
-        instance = EC2Instance(self.client, self.key_pair, instances[0])
+        instance = EC2Instance(self.key_pair, self.client, instances[0])
 
         if wait:
             instance.wait()

--- a/pycloudlib/ec2/instance.py
+++ b/pycloudlib/ec2/instance.py
@@ -16,12 +16,12 @@ class EC2Instance(BaseInstance):
 
     _type = 'ec2'
 
-    def __init__(self, client, key_pair, instance):
+    def __init__(self, key_pair, client, instance):
         """Set up instance.
 
         Args:
-            client: boto3 client object
             key_pair: SSH key object
+            client: boto3 client object
             instance: created boto3 instance object
         """
         super(EC2Instance, self).__init__(key_pair)
@@ -31,6 +31,15 @@ class EC2Instance(BaseInstance):
         self._client = client
 
         self.boot_timeout = 300
+
+    def __repr__(self):
+        """Create string representation for class."""
+        return '{}(key_pair={}, client={}, instance={})'.format(
+            self.__class__.__name__,
+            self.key_pair,
+            self._client,
+            self._instance
+        )
 
     @property
     def availability_zone(self):
@@ -47,6 +56,11 @@ class EC2Instance(BaseInstance):
     def id(self):
         """Return id of instance."""
         return self._instance.instance_id
+
+    @property
+    def name(self):
+        """Return id of instance."""
+        return self.id
 
     @property
     def image_id(self):

--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -42,6 +42,19 @@ class GCE(BaseCloud):
         self.region = region
         self.zone = '%s-%s' % (region, zone)
 
+    def released_image(self, release):
+        """ID of the latest released image for a particular release.
+
+        Args:
+            release: The release to look for
+
+        Returns:
+            A single string with the latest released image ID for the
+            specified release.
+
+        """
+        raise NotImplementedError
+
     def daily_image(self, release, arch='amd64'):
         """Find the id of the latest image for a particular release.
 
@@ -62,6 +75,18 @@ class GCE(BaseCloud):
             Exception('No images found')
 
         return 'projects/ubuntu-os-cloud-devel/global/images/%s' % image_id
+
+    def image_serial(self, image_id):
+        """Find the image serial of the latest daily image for a particular release.
+
+        Args:
+            image_id: string, Ubuntu image id
+
+        Returns:
+            string, serial of latest image
+
+        """
+        raise NotImplementedError
 
     def delete_image(self, image_id):
         """Delete an image.

--- a/pycloudlib/kvm/instance.py
+++ b/pycloudlib/kvm/instance.py
@@ -22,10 +22,19 @@ class KVMInstance(BaseInstance):
 
         self._name = name
 
+    def __repr__(self):
+        """Create string representation for class."""
+        return '{}(name={})'.format(self.__class__.__name__, self.name)
+
     @property
     def name(self):
         """Return instance name."""
         return self._name
+
+    @property
+    def ip(self):
+        """Return IP address of instance."""
+        raise NotImplementedError
 
     @property
     def state(self):
@@ -57,11 +66,12 @@ class KVMInstance(BaseInstance):
         Args:
             wait: wait for delete
         """
+        if not wait:
+            raise ValueError(
+                'wait=False not supported for KVM instance delete'
+            )
         self._log.debug('deleting %s', self.name)
         subp(['multipass', 'delete', '--purge', self.name])
-
-        if wait:
-            self.wait_for_delete()
 
     def pull_file(self, remote_path, local_path):
         """Pull file from an instance.
@@ -104,14 +114,15 @@ class KVMInstance(BaseInstance):
         Args:
             wait: boolean, wait for instance to shutdown
         """
+        if not wait:
+            raise ValueError(
+                'wait=False not supported for KVM instance shutdown'
+            )
         if self.state == 'Stopped':
             return
 
         self._log.debug('shutting down %s', self.name)
         subp(['multipass', 'stop', self.name])
-
-        if wait:
-            self.wait_for_stop()
 
     def start(self, wait=True):
         """Start instance.
@@ -137,9 +148,11 @@ class KVMInstance(BaseInstance):
 
         Not used for KVM.
         """
+        raise NotImplementedError
 
     def wait_for_stop(self):
         """Wait for stop.
 
         Not used for KVM.
         """
+        raise NotImplementedError

--- a/pycloudlib/oci/instance.py
+++ b/pycloudlib/oci/instance.py
@@ -34,10 +34,18 @@ class OciInstance(BaseInstance):
         self.compute_client = oci.core.ComputeClient(config)
         self.network_client = oci.core.VirtualNetworkClient(config)
 
-    def __str__(self):
+    def __repr__(self):
         """Create string representation of class."""
-        return 'OciInstance(instance_id={}, compartment_id={}'.format(
-            self.instance_id, self.compartment_id)
+        return '{}(instance_id={}, compartment_id={})'.format(
+            self.__class__.__name__,
+            self.instance_id,
+            self.compartment_id,
+        )
+
+    @property
+    def name(self):
+        """Return the instance name."""
+        return self.instance_id
 
     @property
     def ip(self):
@@ -112,7 +120,6 @@ class OciInstance(BaseInstance):
             current_data=self.instance_data,
             desired_state='RUNNING',
         )
-        self.execute('/usr/bin/cloud-init status --wait --long')
 
     def wait_for_delete(self):
         """Wait for instance to be deleted."""

--- a/pycloudlib/util.py
+++ b/pycloudlib/util.py
@@ -6,6 +6,7 @@ import datetime
 from errno import ENOENT
 import platform
 import os
+import re
 import shlex
 import subprocess
 import tempfile
@@ -303,3 +304,20 @@ def get_timestamped_tag(tag):
     return'%s-%s' % (
         tag, datetime.datetime.now().strftime("%m%d-%H%M%S")
     )
+
+
+def validate_tag(tag):
+    """Ensure tag will work as name for clouds that use it."""
+    # Currently google is the most restrictive, so just use that
+    # regex verbatum. You can trigger the error message that contains
+    # this regex by attempting to create an instance with a name
+    # of '-'
+    regex = r'^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$'
+    if not re.match(regex, tag):
+        raise ValueError(
+            'Invalid tag specified. After being timestamped, '
+            'tag must pass regex.\n'
+            'Regex: {}\n'
+            'Tag  : {}'.format(regex, tag)
+        )
+    return tag


### PR DESCRIPTION
The goal here is to have the base class be consistent with the implementing classes.

I've made the base cloud and instance classes officially inherit from ABC and added abstract decorators to all of the relevant methods/properties. This will give us more much detailed type/linting info and errors if we have a mismatch or unimplemented method in an implementing class.

I also changed all of the method signatures across the implementations to use the same API as the base class. Where certain APIs might request more to be passed in, the base class provides `**kwargs` that can be overridden.

Since none of the remaining TODOs are code-focused, I think this can be reviewed now.

TODO:
 * Test for every cloud. As of right now I've only verified my changes on LXD
 * Update `boot-speed/clouds/measure-cloud.py` in `server-test-scripts` right before/after this change lands.