### PR TITLE
requirements: downgrade the azure-mgmt-resource dep to 10.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ paramiko==2.7.1
 pyyaml==5.1
 requests==2.22
 oci==2.17.0
-azure-mgmt-resource==10.1.0
+azure-mgmt-resource==10.0.0
 azure-mgmt-network==11.0.0
 azure-mgmt-compute==13.0.0
 azure-cli-core==2.9.1


### PR DESCRIPTION
Avoids the following error:

The conflict is caused by:
    The user requested azure-mgmt-resource==10.1.0
    azure-cli-core 2.9.1 depends on azure-mgmt-resource==10.0.0

No newer version of azure-cli-core is available.