### PR TITLE
Add timeout to paramiko connect

### DIFF
--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -34,8 +34,10 @@ class BaseInstance(ABC):
         self.key_pair = key_pair
         self.port = '22'
         self.username = 'ubuntu'
+        self.connect_timeout = 60
 
-    @abstractproperty
+    @abstractmethod
+    @property
     def name(self):
         """Return instance name."""
         raise NotImplementedError
@@ -311,6 +313,7 @@ class BaseInstance(ABC):
                     username=self.username,
                     hostname=self.ip,
                     port=int(self.port),
+                    timeout=self.connect_timeout,
                     key_filename=self.key_pair.private_key_path,
                 )
                 self._ssh_client = client
@@ -318,6 +321,10 @@ class BaseInstance(ABC):
             except (ConnectionRefusedError, AuthenticationException,
                     BadHostKeyException, ConnectionResetError, SSHException,
                     OSError) as e:
+                self._log.info(
+                    "%s\nRetrying ssh connection %d more time(s) to  %s@%s:%s",
+                    e, retries, self.username, self.ip, self.port
+                )
                 last_exception = e
                 retries -= 1
                 time.sleep(10)


### PR DESCRIPTION
In `uaclient` we are having a problem with connectivity issues regarding paramiko connect. One hypothesis that we have is that the connect get `stuck` and since we have no timeout on that operation, it hangs indefinitely. This PR is adding a timeout parameter to this operation.

Although this should be parametrized by all instance types, I think it is better to wait for #9 to land, to make that consistent. Also, we could also check if the timeout issue will actually fix the uaclient problem.