### PR TITLE
Fix stdout+stderr redirection to /dev/null

### DIFF
--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -355,7 +355,7 @@ class BaseInstance(ABC):
         """Wait until system is fully booted and cloud-init has finished."""
         # runlevel 'N 2' supports distros without recent cloud-init (trusty).
         cloud_init_wait_or_runlevel_result = (
-            "cloud-init status --wait 2&>1 > /dev/null || "
+            "cloud-init status --wait > /dev/null 2>&1 || "
             "[[ $(runlevel) = 'N 2' ]] && [ -f /run/cloud-init/result.json ]"
         )
         cmd = (


### PR DESCRIPTION
This started by fixing a bug in the deleted code:

  cloud-init status --wait 2&>1 > /dev/null

should have been:

  cloud-init status --wait > /dev/null 2>&1

however now that Trusty reached EOL we can just assume that
`cloud-init status --wait` is available and drop the wait
logic based on polling runlevel(8).