### PR TITLE
Fix order of decorators in instance module

### DIFF
--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -36,8 +36,8 @@ class BaseInstance(ABC):
         self.username = 'ubuntu'
         self.connect_timeout = 60
 
-    @abstractmethod
     @property
+    @abstractmethod
     def name(self):
         """Return instance name."""
         raise NotImplementedError


### PR DESCRIPTION
With the current decorator order for the `name` method in the `instance` module we raise the following error when trying to run the code:

```python
File "/usr/lib/python3.6/abc.py", line 25, in abstractmethod
    funcobj.__isabstractmethod__ = True
AttributeError: attribute '__isabstractmethod__' of 'property' objects is not writable
```

This is raised because the decorator order is incorrect.