### PR TITLE
Cloud add timestamp suffix param and initial unit tests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,8 @@ jobs=4
 # R0903: Too few public methods (%s/%s)
 # R0913: Too many arguments
 # C0103: Invalid name
-disable=R0902, R0903, R0913, W0221, C0103
+# R0201: Method could be a function (no-self-use)
+disable=R0902, R0903, R0913, W0221, C0103, R0201
 
 [TYPECHECK]
 # Ignore the googleapiclient module to avoid no-member checks

--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -26,8 +26,10 @@ class Azure(BaseCloud):
         "focal": "Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts"
     }
 
-    def __init__(self, tag, client_id=None, client_secret=None,
-                 subscription_id=None, tenant_id=None, region="centralus"):
+    def __init__(
+        self, tag, timestamp_suffix=True, client_id=None, client_secret=None,
+        subscription_id=None, tenant_id=None, region="centralus"
+    ):
         """Initialize the connection to Azure.
 
         Azure will try to read user credentials form the /home/$USER/.azure
@@ -36,13 +38,15 @@ class Azure(BaseCloud):
 
         Args:
             tag: string used to name and tag resources with
+            timestamp_suffix: bool set True to append a timestamp suffix to the
+                tag
             client_id: user's client id
             client_secret: user's client secret access key
             subscription_id: user's subscription id key
             tenant_id: user's tenant id key
             region: The region where the instance will be created
         """
-        super().__init__(tag)
+        super().__init__(tag, timestamp_suffix)
         self._log.debug('logging into Azure')
         self.location = region
         self.username = "ubuntu"

--- a/pycloudlib/cloud.py
+++ b/pycloudlib/cloud.py
@@ -15,11 +15,12 @@ class BaseCloud(ABC):
 
     _type = 'base'
 
-    def __init__(self, tag):
+    def __init__(self, tag, timestamp_suffix=True):
         """Initialize base cloud class.
 
         Args:
             tag: string used to name and tag resources with
+            timestamp_suffic: Append a timestamped suffix to the tag string.
         """
         self._log = logging.getLogger(__name__)
 
@@ -27,7 +28,10 @@ class BaseCloud(ABC):
         self.key_pair = KeyPair(
             '/home/%s/.ssh/id_rsa.pub' % _username, name=_username
         )
-        self.tag = validate_tag(get_timestamped_tag(tag))
+        if timestamp_suffix:
+            self.tag = validate_tag(get_timestamped_tag(tag))
+        else:
+            self.tag = validate_tag(tag)
 
     @abstractmethod
     def delete_image(self, image_id):

--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -15,8 +15,10 @@ class EC2(BaseCloud):
 
     _type = 'ec2'
 
-    def __init__(self, tag, access_key_id=None, secret_access_key=None,
-                 region=None):
+    def __init__(
+        self, tag, timestamp_suffix=True, access_key_id=None,
+        secret_access_key=None, region=None
+    ):
         """Initialize the connection to EC2.
 
         boto3 will read a users /home/$USER/.aws/* files if no
@@ -24,11 +26,13 @@ class EC2(BaseCloud):
 
         Args:
             tag: string used to name and tag resources with
+            timestamp_suffix: bool set True to append a timestamp suffix to the
+                tag
             access_key_id: user's access key ID
             secret_access_key: user's secret access key
             region: region to login to
         """
-        super().__init__(tag)
+        super().__init__(tag, timestamp_suffix)
         self._log.debug('logging into EC2')
 
         try:

--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -21,16 +21,20 @@ logging.getLogger('googleapiclient.discovery').setLevel(logging.WARNING)
 class GCE(BaseCloud):
     """GCE Cloud Class."""
 
-    def __init__(self, tag, project, region, zone):
+    def __init__(
+        self, tag, timestamp_suffix=True, project=None, region=None, zone=None
+    ):
         """Initialize the connection to GCE.
 
         Args:
-            tag:
+            tag: string used to name and tag resources with
+            timestamp_suffix: bool set True to append a timestamp suffix to the
+                tag
             project:
             region:
             zone:
         """
-        super().__init__(tag)
+        super().__init__(tag, timestamp_suffix)
         self._log.debug('logging into GCE')
 
         # disable cache_discovery due to:

--- a/pycloudlib/kvm/cloud.py
+++ b/pycloudlib/kvm/cloud.py
@@ -17,15 +17,7 @@ class KVM(BaseCloud):  # pylint: disable=W0223
     _type = 'kvm'
     _daily_remote = 'daily'
     _releases_remote = 'release'
-
-    def __init__(self, tag):
-        """Initialize KVM cloud class.
-
-        Args:
-            tag: string used to name and tag resources with
-        """
-        super().__init__(tag)
-        self._instance_types = None
+    _instance_types = None
 
     def delete_instance(self, instance_name, wait=True):
         """Delete an instance.

--- a/pycloudlib/oci/cloud.py
+++ b/pycloudlib/oci/cloud.py
@@ -18,7 +18,10 @@ class OCI(BaseCloud):
 
     _type = 'oci'
 
-    def __init__(self, tag, compartment_id, config_path='~/.oci/config'):
+    def __init__(
+        self, tag, timestamp_suffix=True, compartment_id=None,
+        config_path='~/.oci/config',
+    ):
         """
         Initialize the connection to OCI.
 
@@ -27,11 +30,13 @@ class OCI(BaseCloud):
 
         Args:
             tag: Name of instance
+            timestamp_suffix: bool set True to append a timestamp suffix to the
+                tag
             compartment_id: A compartment found at
                 https://console.us-phoenix-1.oraclecloud.com/a/identity/compartments
             config_path: Path of OCI config file
         """
-        super().__init__(tag)
+        super().__init__(tag, timestamp_suffix)
         self.compartment_id = compartment_id
 
         if not os.path.isfile(os.path.expanduser(config_path)):

--- a/pycloudlib/tests/__init__.py
+++ b/pycloudlib/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests related to pycloudlib module."""

--- a/pycloudlib/tests/test_cloud.py
+++ b/pycloudlib/tests/test_cloud.py
@@ -1,0 +1,87 @@
+"""Tests related to pycloudlib.cloud module."""
+import mock
+
+import pytest
+
+from pycloudlib.cloud import BaseCloud
+
+# mock module path
+MPATH = "pycloudlib.cloud."
+
+
+class CloudSubclass(BaseCloud):
+    """Create a concrete subclass of BaseCloud for testing."""
+
+    def delete_image(self):
+        """Skeletal delete_image."""
+
+    def released_image(self, release, **kwargs):
+        """Skeletal released_image."""
+
+    def daily_image(self, release, **kwargs):
+        """Skeletal daily_image."""
+
+    def image_serial(self, image_id):
+        """Skeletal image_serial."""
+
+    def get_instance(self, instance_id):  # () -> BaseInstance
+        """Skeletal get_instance."""
+
+    def launch(self, image_id, instance_type=None, user_data=None,
+               wait=True, **kwargs):  # () -> BaseInstance
+        """Skeletal launch."""
+
+    def snapshot(self, instance, clean=True, **kwargs):
+        """Skeletal snapshot."""
+
+    def list_keys(self):
+        """Skeletal list_keys."""
+
+
+class TestBaseCloud:
+    """Tests covering BaseCloud intialization."""
+
+    def test_base_cloud_is_abstract(self):
+        """The BaseCloud needs a concrete subclass to __init__."""
+        with pytest.raises(TypeError) as exc_info:
+            BaseCloud(tag="")  # pylint: disable=E0110
+        assert "Can't instantiate abstract class BaseCloud" in str(
+            exc_info.value
+        )
+
+    @pytest.mark.parametrize(
+        "tag,timestamp_suffix,expected_tag",
+        (
+            ("a", None, "a-timestamp"),
+            ("a", True, "a-timestamp"),
+            ("a", False, "a"),
+        )
+    )
+    @mock.patch(MPATH + 'get_timestamped_tag', return_value="a-timestamp")
+    @mock.patch(MPATH + 'getpass.getuser', return_value="crashoverride")
+    def test_init_sets_timestamped_tag(
+        self,
+        _m_getuser,
+        _m_get_timestamped_tag,
+        tag,
+        timestamp_suffix,
+        expected_tag,
+    ):
+        """The timestamp_suffix param of true adds a tag timestamp suffix."""
+        args = {"tag": tag}
+        if timestamp_suffix in (True, False):
+            args["timestamp_suffix"] = timestamp_suffix
+        mycloud = CloudSubclass(**args)
+        assert expected_tag == mycloud.tag
+
+    @mock.patch(MPATH + 'getpass.getuser', return_value="crashoverride")
+    def test_init_sets_key_pair_based_on_getuser(self, _m_getuser):
+        """The default key_pair for the cloud is based on the current user."""
+        mycloud = CloudSubclass(tag="tag", timestamp_suffix=False)
+        assert mycloud.key_pair.name == "crashoverride"
+        assert mycloud.key_pair.private_key_path == (
+            "/home/crashoverride/.ssh/id_rsa"
+        )
+        assert mycloud.key_pair.public_key_path == (
+            "/home/crashoverride/.ssh/id_rsa.pub"
+        )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+mock
+pytest
+pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,16 @@
 [tox]
-envlist = flake8, pylint
+envlist = flake8, pylint, py3
 recreate = true
 skipsdist = true
+
+[testenv:py3]
+deps =
+    -rrequirements.txt
+    mock
+    pytest
+    pytest-cov
+commands =
+    py3: py.test {posargs:--cov pycloudlib}
 
 [testenv:flake8]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,8 @@ skipsdist = true
 
 [testenv:py3]
 deps =
+    -rtest-requirements.txt
     -rrequirements.txt
-    mock
-    pytest
-    pytest-cov
 commands =
     py3: py.test {posargs:--cov pycloudlib}
 
@@ -21,6 +19,7 @@ commands = {envpython} -m flake8 pycloudlib examples setup.py
 [testenv:pylint]
 deps =
     pylint==2.6.0
+    -rtest-requirements.txt
     -rrequirements.txt
 commands = {envpython} -m pylint pycloudlib examples setup.py
 


### PR DESCRIPTION
Required because ua-tools CI already provides a timestamped tag, so we don't want pycloudlib to tack on a secondary timestamp suffix. Otherwise our tags get rejected.


See: https://travis-ci.org/github/canonical/ubuntu-advantage-client/jobs/723850613#L344