### PR TITLE
trusty: fix instance wait_for_system

### DIFF
--- a/pycloudlib/ec2/instance.py
+++ b/pycloudlib/ec2/instance.py
@@ -212,7 +212,9 @@ class EC2Instance(BaseInstance):
 
     def wait(self):
         """Wait for instance to be up and cloud-init to be complete."""
+        self._log.debug('wait for instance running %s', self._instance.id)
         self._instance.wait_until_running()
+        self._log.debug('reloading instance state %s', self._instance.id)
         self._instance.reload()
         self._wait_for_system()
 


### PR DESCRIPTION
Add stderr to fail to boot output.

This showed why trusty systems were not coming up:

cloud-init failed to start:  error: sh: 1: [: N: unexpected operator
sh: 1: [: N: unexpected operator


Added escaped double quotes around the wait_for_systemd cmd



testing instructions:
```
cat > trusty-test.py <<EOF
import pycloudlib                                                               
import logging                                                                  
                                                                                
def main():                                                                     
    lxd = pycloudlib.LXD('example-basic')                                       
    inst = lxd.launch("ubuntu-daily:trusty")                                    
    inst.console_log()                                                          
                                                                                
    result = inst.execute('uptime')                                             
    print(result)                                                               
    print(result.return_code)                                                   
    print(result.ok)                                                            
    print(result.failed)                                                        
    print(bool(result))                                                         
                                                                                
    inst.shutdown()                                                             
EOF

tox -e py3
.tox/py3/bin/python3 trusty-test.py
```
                                                                                
                                                                                
if __name__ == "__main__":                                                      
    logging.basicConfig(level=logging.DEBUG)                                    
    main()         