### PR TITLE
instance: allow KVM/LXD commands to exit non-zero

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,8 +8,9 @@ jobs=4
 # R0903: Too few public methods (%s/%s)
 # R0913: Too many arguments
 # C0103: Invalid name
+# C0122: misplaced-comparison-constant
 # R0201: Method could be a function (no-self-use)
-disable=R0902, R0903, R0913, W0221, C0103, R0201
+disable=R0902, R0903, R0913, W0221, C0103, C0122, R0201
 
 [TYPECHECK]
 # Ignore the googleapiclient module to avoid no-member checks

--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -150,14 +150,16 @@ class BaseInstance(ABC):
 
         if self._type == 'lxd':
             base_cmd = ['lxc', 'exec', self.name, '--']
-            return subp(base_cmd + list(command))
+            return subp(base_cmd + list(command), rcs=None)
 
         # multipass handling of redirects is buggy, so we don't bind
         # stdin to /dev/null for the moment (shortcircuit_stdin=False).
         # See: https://github.com/CanonicalLtd/multipass/issues/667
         if self._type == 'kvm':
             base_cmd = ['multipass', 'exec', self.name, '--']
-            return subp(base_cmd + list(command), shortcircuit_stdin=False)
+            return subp(
+                base_cmd + list(command), rcs=None, shortcircuit_stdin=False
+            )
 
         return self._ssh(list(command), stdin=stdin)
 

--- a/pycloudlib/tests/test_instance.py
+++ b/pycloudlib/tests/test_instance.py
@@ -1,0 +1,30 @@
+"""Tests related to pycloudlib.instance module."""
+from unittest import mock
+
+import pytest
+
+from pycloudlib.lxd.instance import LXDInstance
+from pycloudlib.kvm.instance import KVMInstance
+
+
+class TestExecute:
+    """Tests covering pycloudlib.instance.Instance.execute.
+
+    TODO: There are elements of `execute` which could be refactored onto the
+          relevant subclasses.  Some of these tests should move along with that
+          refactor.
+    """
+
+    @pytest.mark.parametrize("instance_cls", (LXDInstance, KVMInstance))
+    def test_all_rcs_acceptable(self, instance_cls):
+        """Test that we invoke util.subp with rcs=None.
+
+        rcs=None means that we will get a Result object back for all return
+        codes, rather than an exception for non-zero return codes.
+        """
+        instance = instance_cls(None)
+        with mock.patch("pycloudlib.instance.subp") as m_subp:
+            instance.execute("some_command")
+        assert 1 == m_subp.call_count
+        _args, kwargs = m_subp.call_args
+        assert kwargs.get("rcs", mock.sentinel.not_none) is None


### PR DESCRIPTION
`pycloudlib.util.subp`'s default behaviour is to raise an exception if
the command being executed exits non-zero.  Before this commit, this
meant that executing a command against a LXD or KVM instance that exited
non-zero would raise an exception (instead of returning a `Result`
object as other instances do).

Fixes: #30