### PR TITLE
instance: refactor _wait_for_system to reduce shell script complexity

### DIFF
--- a/pycloudlib/tests/test_instance.py
+++ b/pycloudlib/tests/test_instance.py
@@ -3,8 +3,20 @@ from unittest import mock
 
 import pytest
 
-from pycloudlib.lxd.instance import LXDInstance
+from pycloudlib.instance import BaseInstance
 from pycloudlib.kvm.instance import KVMInstance
+from pycloudlib.lxd.instance import LXDInstance
+from pycloudlib.result import Result
+
+
+@pytest.fixture
+def concrete_instance_cls():
+    """Return a BaseInstance subclass which can be instantiated.
+
+    Source: https://stackoverflow.com/a/28738073
+    """
+    with mock.patch.object(BaseInstance, "__abstractmethods__", set()):
+        yield BaseInstance
 
 
 class TestExecute:
@@ -28,3 +40,87 @@ class TestExecute:
         assert 1 == m_subp.call_count
         _args, kwargs = m_subp.call_args
         assert kwargs.get("rcs", mock.sentinel.not_none) is None
+
+
+class TestWaitForSystem:
+    """Tests covering pycloudlib.instance.Instance._wait_for_system."""
+
+    # Disable this pylint check as fixture usage incorrectly triggers it:
+    # pylint: disable=redefined-outer-name
+    # Disable this one because we're intentionally testing a protected member
+    # pylint: disable=protected-access
+
+    def test_with_wait_available(self, concrete_instance_cls):
+        """Test the happy path for instances with `status --wait`."""
+
+        def side_effect(cmd, *_args, **_kwargs):
+            stdout = ""
+            if "--help" in cmd:
+                stdout = "help content containing --wait"
+            return Result(stdout=stdout, stderr="", return_code=0)
+
+        instance = concrete_instance_cls(key_pair=None)
+        with mock.patch.object(instance, "execute") as m_execute:
+            m_execute.side_effect = side_effect
+            instance._wait_for_system()
+
+        assert 2 == m_execute.call_count
+        assert (
+            mock.call("cloud-init status --help")
+            == m_execute.call_args_list[0]
+        )
+        assert (
+            mock.call(
+                ["cloud-init", "status", "--wait"],
+                description="waiting for start",
+            )
+            == m_execute.call_args_list[1]
+        )
+
+    def test_without_wait_available(self, concrete_instance_cls):
+        """Test the happy path for instances without `status --wait`."""
+
+        def side_effect(cmd, *_args, **_kwargs):
+            stdout = ""
+            if "--help" in cmd:
+                stdout = "help content without wait"
+            return Result(stdout=stdout, stderr="", return_code=0)
+
+        instance = concrete_instance_cls(key_pair=None)
+        with mock.patch.object(instance, "execute") as m_execute:
+            m_execute.side_effect = side_effect
+            instance._wait_for_system()
+
+        assert 2 == m_execute.call_count
+        assert (
+            mock.call("cloud-init status --help")
+            == m_execute.call_args_list[0]
+        )
+        # There's no point checksum testing the full shellscript: test enough
+        # to be sure we've got the right thing.
+        first_arg = m_execute.call_args_list[1][0][0]
+        assert "runlevel" in first_arg
+        assert "result.json" in first_arg
+
+    @pytest.mark.parametrize("has_wait", [True, False])
+    def test_failure_path(self, has_wait, concrete_instance_cls):
+        """Test failure for both has_wait and !has_wait cases."""
+
+        def side_effect(cmd, *_args, **_kwargs):
+            stdout = ""
+            if "--help" in cmd:
+                # The --help call should be successful, and contain the
+                # appropriate output to select --wait or not
+                if has_wait:
+                    stdout = "help content containing --wait"
+                return Result(stdout=stdout, stderr="", return_code=0)
+            # Any other call should fail
+            return Result(stdout="fail_out", stderr="fail_err", return_code=1)
+
+        instance = concrete_instance_cls(key_pair=None)
+        with mock.patch.object(instance, "execute") as m_execute:
+            m_execute.side_effect = side_effect
+            with pytest.raises(OSError) as excinfo:
+                instance._wait_for_system()
+
+        assert "out: fail_out error: fail_err" in str(excinfo.value)


### PR DESCRIPTION
Doing everything within a single shell script makes it hard to
interrogate why failure was reported.  The refactored code will only run
the part of the shell script which is relevant to the system under test:
`cloud-init status --wait` if available, otherwise the while loop using
`runlevel`.

Also add tests for `_wait_for_system`.