### PR TITLE
instance: refactor BaseInstance.wait

### DIFF
--- a/pycloudlib/azure/instance.py
+++ b/pycloudlib/azure/instance.py
@@ -140,10 +140,6 @@ class AzureInstance(BaseInstance):
 
         self.status = "deleted"
 
-    def wait(self):
-        """Wait for instance to be up and cloud-init to be complete."""
-        self._wait_for_system()
-
     def console_log(self):
         """Return the instance console log."""
         raise NotImplementedError

--- a/pycloudlib/ec2/instance.py
+++ b/pycloudlib/ec2/instance.py
@@ -210,13 +210,12 @@ class EC2Instance(BaseInstance):
         if wait:
             self.wait()
 
-    def wait(self):
-        """Wait for instance to be up and cloud-init to be complete."""
+    def _wait_for_instance_start(self):
+        """Wait for instance to be up."""
         self._log.debug('wait for instance running %s', self._instance.id)
         self._instance.wait_until_running()
         self._log.debug('reloading instance state %s', self._instance.id)
         self._instance.reload()
-        self._wait_for_system()
 
     def wait_for_delete(self):
         """Wait for instance to be deleted."""

--- a/pycloudlib/gce/instance.py
+++ b/pycloudlib/gce/instance.py
@@ -135,11 +135,10 @@ class GceInstance(BaseInstance):
         if wait:
             self.wait()
 
-    def wait(self):
+    def _wait_for_instance_start(self):
         """Wait for instance to be up."""
         self._wait_for_status('RUNNING')
         self._ip = self._get_ip()
-        self._wait_for_system()
 
     def wait_for_delete(self, sleep_seconds=300):
         """Wait for instance to be deleted."""

--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -84,10 +84,17 @@ class BaseInstance(ABC):
         """
         raise NotImplementedError
 
-    @abstractmethod
+    def _wait_for_instance_start(self):
+        """Wait for the cloud instance to be up.
+
+        Subclasses should implement this if their cloud provides a way of
+        detecting when an instance has started through their API.
+        """
+
     def wait(self):
         """Wait for instance to be up and cloud-init to be complete."""
-        raise NotImplementedError
+        self._wait_for_instance_start()
+        self._wait_for_cloudinit()
 
     @abstractmethod
     def wait_for_delete(self):
@@ -358,7 +365,7 @@ class BaseInstance(ABC):
         self._tmp_count += 1
         return path
 
-    def _wait_for_system(self):
+    def _wait_for_cloudinit(self):
         """Wait until system is fully booted and cloud-init has finished."""
         self._log.debug('wait_for_system cloud-init completion')
 

--- a/pycloudlib/kvm/instance.py
+++ b/pycloudlib/kvm/instance.py
@@ -139,10 +139,6 @@ class KVMInstance(BaseInstance):
         if wait:
             self.wait()
 
-    def wait(self):
-        """Wait for instance to be up and cloud-init to be complete."""
-        self._wait_for_system()
-
     def wait_for_delete(self):
         """Wait for delete.
 

--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -261,10 +261,6 @@ class LXDInstance(BaseInstance):
         if wait:
             self.wait()
 
-    def wait(self):
-        """Wait for instance to be up and cloud-init to be complete."""
-        self._wait_for_system()
-
     def wait_for_delete(self):
         """Wait for delete.
 

--- a/pycloudlib/oci/instance.py
+++ b/pycloudlib/oci/instance.py
@@ -113,8 +113,8 @@ class OciInstance(BaseInstance):
         if wait:
             self.wait()
 
-    def wait(self):
-        """Wait for instance to be up and cloud-init to be complete."""
+    def _wait_for_instance_start(self):
+        """Wait for instance to be up."""
         wait_till_ready(
             func=self.compute_client.get_instance,
             current_data=self.instance_data,


### PR DESCRIPTION
This modifies BaseInstance.wait from an abstract to a concrete method
which calls `self._wait_for_start` then `self._wait_for_system`.  This
ensures that we will always call `self._wait_for_system` when `wait` is
called, while still allowing subclasses to define their own additional
waiting logic.

Any existing subclass `wait` implementations which only called
`self._wait_for_system` have been removed (as the superclass now
performs that itself).  The remaining implementations have been renamed
to `_wait_for_start` and have had any calls to `self._wait_for_system`
removed (as the superclass will now do that).

Fixes #35