### PR TITLE
instance: add `--long` to `cloud-init status --wait` call

### DIFF
--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -372,7 +372,7 @@ class BaseInstance(ABC):
         has_wait = "--wait" in self.execute("cloud-init status --help").stdout
 
         if has_wait:
-            cmd = ["cloud-init", "status", "--wait"]
+            cmd = ["cloud-init", "status", "--wait", "--long"]
         else:
             # runlevel 'N 2' supports distros without recent cloud-init
             # (e.g. trusty).

--- a/pycloudlib/tests/test_instance.py
+++ b/pycloudlib/tests/test_instance.py
@@ -89,7 +89,7 @@ class TestWaitForSystem:
         )
         assert (
             mock.call(
-                ["cloud-init", "status", "--wait"],
+                ["cloud-init", "status", "--wait", "--long"],
                 description="waiting for start",
             )
             == m_execute.call_args_list[1]


### PR DESCRIPTION
This means that the error message included in the raised `OSError` on
failure contains some information about the failure (rather than just
the dots that `--wait` causes to be emitted).