### PR TITLE
Stop depending on specific versions of dependencies

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,8 +9,9 @@ jobs=4
 # R0913: Too many arguments
 # C0103: Invalid name
 # C0122: misplaced-comparison-constant
+# C0301: line-too-long  (flake8 already catches this for us)
 # R0201: Method could be a function (no-self-use)
-disable=R0902, R0903, R0913, W0221, C0103, C0122, R0201
+disable=R0902, R0903, R0913, W0221, C0103, C0122, C0301, R0201
 
 [TYPECHECK]
 # Ignore the googleapiclient module to avoid no-member checks

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,1 @@
-boto3==1.14.20
-botocore==1.17.20
-google-api-python-client==1.7.7
-paramiko==2.7.1
-pyyaml==5.1
-requests==2.22
-oci==2.17.0
-azure-mgmt-resource==10.0.0
-azure-mgmt-network==11.0.0
-azure-mgmt-compute==13.0.0
-azure-cli-core==2.9.1
-knack==0.7.1
-
-# Simplestreams is not found on PyPi so pull from repo directly
-python-simplestreams @ git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d
+-e .

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,23 @@ def read_readme():
     return readme_txt
 
 
-PKGS = open('requirements.txt', 'r').readlines()
+INSTALL_REQUIRES = [
+    "boto3 >= 1.14.20",
+    "botocore >= 1.17.20",
+    "google-api-python-client >= 1.7.7",
+    "paramiko >= 2.7.1",
+    "pyyaml >= 5.1",
+    "requests >= 2.22",
+    "oci >= 2.17.0",
+    "azure-mgmt-resource >= 10.0.0, < 15",
+    "azure-mgmt-network >= 11.0.0, < 16",
+    "azure-mgmt-compute >= 13.0.0, < 17",
+    "azure-cli-core >= 2.9.1",
+    "knack >= 0.7.1",
+
+    # Simplestreams is not found on PyPi so pull from repo directly
+    "python-simplestreams @ git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d",  # noqa
+]
 
 setup(
     name='pycloudlib',
@@ -30,7 +46,7 @@ setup(
     license='GNU General Public License v3 (GPLv3)',
     packages=find_packages(),
     python_requires='>=3.4',
-    install_requires=PKGS,
+    install_requires=INSTALL_REQUIRES,
     zip_safe=True,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
As a library, pycloudlib should allow consumers to select precisely the versions of dependencies that they want to use. This commit achieves that by specifying lower (and where necessary, upper) bounds on the versions required, instead of specific versions.

It moves these specifications from `requirements.txt` to `setup.py`: per https://packaging.python.org/discussions/install-requires-vs-requirements/, this is the appropriate place for libraries to express their dependencies. `requirements.txt` will now install the local version of the library.

Fixes #41

## Testing

### cloud-init

Test that the integration tests work (to the same level as `master`) on:

- [x] Azure
- [x] EC2
- [x] GCE
- [x] LXD container
- [x] Oracle

The [`deps` branch in my repo](https://github.com/OddBloke/cloud-init/tree/deps) is the corresponding refactor of cloud-init's dependencies, and currently has this proposed branch hard-coded as its `pycloudlib` dependency; this allows for easier testing of cloud-init.

### ubuntu-advantage-client

Test that the behave tests work (to the same level as `master`) on:

- [x] Azure
- [x] EC2
- [x] LXD container # not applicable (pycloudlib not used yet)
- [x] LXD VM           # not applicable (pycloudlib not used yet)