### PR TITLE
Retry cloudinit wait on all LXD instance types

### DIFF
--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -99,6 +99,7 @@ class BaseInstance(ABC):
             complete successfully.
         """
         self._wait_for_instance_start()
+        self._wait_for_execute()
         self._wait_for_cloudinit(raise_on_failure=raise_on_cloudinit_failure)
 
     @abstractmethod
@@ -361,6 +362,32 @@ class BaseInstance(ABC):
         self._tmp_count += 1
         return path
 
+    def _wait_for_execute(self):
+        """Wait until we can execute a command in the instance."""
+        self._log.debug('_wait_for_execute to complete')
+
+        test_instance_command = "whoami"
+        result = self.execute(test_instance_command)
+        if result.failed:
+            retries = 10
+            while retries:
+                result = self.execute(test_instance_command)
+
+                if result.ok:
+                    break
+
+                retries -= 1
+                time.sleep(10)
+
+        if result.failed:
+            raise OSError(
+                "{}\n{}".format(
+                    "Instance can't be reached",
+                    "Failed to execute {} command".format(
+                        test_instance_command)
+                )
+            )
+
     def _wait_for_cloudinit(self, *, raise_on_failure: bool):
         """Wait until cloud-init has finished.
 
@@ -369,7 +396,9 @@ class BaseInstance(ABC):
             then this method will raise an `OSError`.
         """
         self._log.debug('_wait_for_cloudinit to complete')
-        has_wait = "--wait" in self.execute("cloud-init status --help").stdout
+
+        result = self.execute("cloud-init status --help")
+        has_wait = "--wait" in result.stdout
 
         if has_wait:
             cmd = ["cloud-init", "status", "--wait", "--long"]

--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -354,7 +354,6 @@ class LXDInstance(BaseInstance):
                     # lxd vms. However, if we wait a moment before trying
                     # again, the error fades away. That's why we are treating
                     # it here.
-                    print("cloud-init failed to start: out: ......." in str(e))
                     if "cloud-init failed to start: out: ......." in str(e):
                         time.sleep(sleep_time)
                         continue

--- a/pycloudlib/tests/test_instance.py
+++ b/pycloudlib/tests/test_instance.py
@@ -67,6 +67,7 @@ class TestWait:
         with mock.patch.multiple(
             instance,
             _wait_for_instance_start=mock.DEFAULT,
+            _wait_for_execute=mock.DEFAULT,
             _wait_for_cloudinit=mock.DEFAULT,
         ) as mocks:
             if raise_on_cloudinit_failure is not None:
@@ -77,12 +78,33 @@ class TestWait:
                 instance.wait()
 
         assert 1 == mocks["_wait_for_instance_start"].call_count
+        assert 1 == mocks["_wait_for_execute"].call_count
         assert 1 == mocks["_wait_for_cloudinit"].call_count
         kwargs = mocks["_wait_for_cloudinit"].call_args[1]
         if raise_on_cloudinit_failure is None:
             # We expect True by default
             raise_on_cloudinit_failure = True
         assert kwargs["raise_on_failure"] == raise_on_cloudinit_failure
+
+    @mock.patch.object(BaseInstance, "execute")
+    @mock.patch("pycloudlib.instance.time.sleep")
+    def test_wait_execute_failure(
+        self, m_sleep, m_execute, concrete_instance_cls
+    ):
+        """Test wait calls when execute command fails."""
+        instance = concrete_instance_cls(key_pair=None)
+        m_execute.return_value = Result(stdout="", stderr="", return_code=1)
+        expected_msg = "{}\n{}".format(
+            "Instance can't be reached", "Failed to execute whoami command"
+        )
+        expected_call_args = [mock.call("whoami")] * 11
+
+        with pytest.raises(OSError) as excinfo:
+            instance.wait()
+
+        assert expected_msg == str(excinfo.value)
+        assert expected_call_args == m_execute.call_args_list
+        assert m_sleep.call_count == 10
 
 
 class TestWaitForCloudinit:
@@ -159,6 +181,11 @@ class TestWaitForCloudinit:
 
         def side_effect(cmd, *_args, **_kwargs):
             stdout = ""
+            if "whoami" == cmd:
+                # The whoami call should be successful and inform us
+                # that the instance can be reached
+                return Result(stdout=stdout, stderr="", return_code=0)
+
             if "--help" in cmd:
                 # The --help call should be successful, and contain the
                 # appropriate output to select --wait or not


### PR DESCRIPTION
Currently, the `images:ubuntu/16.04/cloud` errors out when we try to run the `_wait_for_cloudinit`  method. If we retry on that first error, the instance is launched without an issue. To address that, we are relaxing the retry check we have on `_wait_for_cloudinit`