### PR TITLE
Run lxc commands as non root by default

### DIFF
--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -23,6 +23,7 @@ class LXDInstance(BaseInstance):
         super().__init__(key_pair=key_pair)
 
         self._name = name
+        self._user_id = None
 
     def __repr__(self):
         """Create string representation for class."""
@@ -33,7 +34,9 @@ class LXDInstance(BaseInstance):
         if self.key_pair:
             return super()._run_command(command, stdin)
 
-        base_cmd = ['lxc', 'exec', self.name, '--']
+        base_cmd = [
+            'lxc', 'exec', self.name, '--', 'sudo', '-u', self.username, '--'
+        ]
         return subp(base_cmd + list(command), rcs=None)
 
     @property

--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -23,7 +23,6 @@ class LXDInstance(BaseInstance):
         super().__init__(key_pair=key_pair)
 
         self._name = name
-        self._user_id = None
 
     def __repr__(self):
         """Create string representation for class."""


### PR DESCRIPTION
In ubuntu-advantage-tools, we require some LXD commands to be run as `non-root`. This PR changes the default behavior of LXD to run exec commands as non-root.

This will impact some `cloud-init` tests, but we already have a [PR](https://github.com/canonical/cloud-init/pull/664) to handle that