### PR TITLE
Make _build_necessary_profiles part of the public LXD API

### DIFF
--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -594,7 +594,7 @@ class LXDVirtualMachine(_BaseLXD):
         # identify the release.
         return self._image_info(image_id)[0]["release"]
 
-    def _build_necessary_profiles(self, release=None):
+    def build_necessary_profiles(self, release=None):
         """Build necessary profiles to launch the LXD instance.
 
         Args:
@@ -637,7 +637,7 @@ class LXDVirtualMachine(_BaseLXD):
             launch the LXD instance.
         """
         if not profile_list:
-            profile_list = self._build_necessary_profiles(release=release)
+            profile_list = self.build_necessary_profiles(release=release)
 
         cmd = super()._prepare_command(
             name=name,


### PR DESCRIPTION
_build_necessary_profiles is called on every VM launch. Part of doing that is looking up the image being used to get the OS in use. If I've generated an LXD snapshot, that won't work, because I'm using a `local:` source, so I would like to cache the generated profile in cloud-init tests, thus requiring `build_necessary_profiles` to be part of the public API.