### PR TITLE
lxd: don't attach config disk to focal+ LXD VMs

### DIFF
--- a/pycloudlib/lxd/defaults.py
+++ b/pycloudlib/lxd/defaults.py
@@ -46,18 +46,19 @@ VM_PROFILE_TMPL = textwrap.dedent(
     """
 )
 
+
+def _make_vm_profile(
+    series: str, *, install_agent: bool, install_ssh: bool = False
+) -> str:
+    vendordata = "config: {}"
+    if install_agent:
+        custom_cfg = "packages: [openssh-server]" if install_ssh else ""
+        vendordata = LXC_SETUP_VENDORDATA.format(custom_cfg=custom_cfg)
+    return VM_PROFILE_TMPL.format(series=series, vendordata=vendordata)
+
+
 base_vm_profiles = {
-    "xenial": VM_PROFILE_TMPL.format(
-        vendordata=LXC_SETUP_VENDORDATA.format(
-            custom_cfg="packages: [openssh-server]"),
-        series="xenial"
-    ),
-    "bionic": VM_PROFILE_TMPL.format(
-        vendordata=LXC_SETUP_VENDORDATA.format(custom_cfg=""),
-        series="bionic"
-    ),
-    "focal": VM_PROFILE_TMPL.format(
-        vendordata="config: {}",
-        series="focal"
-    )
+    "xenial": _make_vm_profile("xenial", install_agent=True, install_ssh=True),
+    "bionic": _make_vm_profile("bionic", install_agent=True),
+    "focal": _make_vm_profile("focal", install_agent=False),
 }


### PR DESCRIPTION
Per a comment from stgraber[0], the config disk is "only used for legacy images that do not have the agent".  As the agent is present in focal and later, instances using these profiles do not need to attach the config disk. (This is pertinent because until https://github.com/lxc/lxd/pull/8182 is released, we cannot use network configuration via the config disk.)

This change also switches us to using the KVM disk images for focal and later, for full agent support.

[0] https://github.com/lxc/lxd/issues/7292#issuecomment-733143079