### PR TITLE
Update travis to run cloudinit test with daily ppa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ matrix:
           - sudo usermod -a -G lxd $USER
           - git clone https://github.com/canonical/cloud-init.git
           - cd cloud-init
-          - sg lxd -c "pytest tests/integration_tests/"
+          - sg lxd -c "CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily pytest tests/integration_tests/"


### PR DESCRIPTION
Our current travis build is running the cloud-init integration tests with the current cloud-init version. This is problematic
because some of the tests on cloud-init assume that we are using the most recent version of the package. To fix that, we
will be using the cloud-init package from our daily ppa to run the integration tests