### PR TITLE
Allow GCE cloud to create ssh keys

### DIFF
--- a/examples/gce.py
+++ b/examples/gce.py
@@ -3,6 +3,7 @@
 """Basic examples of various lifecycle with an GCE instance."""
 
 import logging
+import os
 
 import pycloudlib
 
@@ -15,12 +16,32 @@ def demo():
     """
     gce = pycloudlib.GCE(
         tag='examples',
-        project='my_project_name',
+        project='canonical-dev',
         region='us-west2',
         zone='a'
     )
     daily = gce.daily_image('bionic')
-    gce.launch(daily)
+
+    pub_key_path = "gce-pubkey"
+    priv_key_path = "gce-privkey"
+    pub_key, priv_key = gce.create_key_pair()
+
+    with open(pub_key_path, "w") as f:
+        f.write(pub_key)
+
+    with open(priv_key_path, "w") as f:
+        f.write(priv_key)
+
+    os.chmod(pub_key_path, 0o600)
+    os.chmod(priv_key_path, 0o600)
+
+    gce.use_key(
+        public_key_path=pub_key_path,
+        private_key_path=priv_key_path
+    )
+
+    inst = gce.launch(daily)
+    print(inst.execute("lsb_release -a"))
 
 
 if __name__ == '__main__':

--- a/pycloudlib/cloud.py
+++ b/pycloudlib/cloud.py
@@ -1,9 +1,11 @@
 # This file is part of pycloudlib. See LICENSE file for license information.
 """Base class for all other clouds to provide consistent set of functions."""
 
+import io
 import getpass
 import logging
 from abc import ABC, abstractmethod
+import paramiko
 
 from pycloudlib.key import KeyPair
 from pycloudlib.streams import Streams
@@ -136,6 +138,20 @@ class BaseCloud(ABC):
 
         """
         raise NotImplementedError
+
+    def create_key_pair(self):
+        """Create and set a ssh key pair for a cloud instance.
+
+        Returns:
+            A tuple containing the public and private key created
+        """
+        key = paramiko.RSAKey.generate(4096)
+        priv_str = io.StringIO()
+
+        pub_key = "{} {}".format(key.get_name(), key.get_base64())
+        key.write_private_key(priv_str, password=None)
+
+        return pub_key, priv_str.getvalue()
 
     def use_key(self, public_key_path, private_key_path=None, name=None):
         """Use an existing key.

--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -168,7 +168,7 @@ class GCE(BaseCloud):
             "metadata": {
                 "items": [{
                     "key": "ssh-keys",
-                    "value": "admin:%s" % self.key_pair.public_key_content,
+                    "value": "ubuntu:%s" % self.key_pair.public_key_content,
                 }]
             },
         }

--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -1,11 +1,9 @@
 # This file is part of pycloudlib. See LICENSE file for license information.
 """LXD Cloud type."""
-import io
 import re
 import textwrap
 from abc import abstractmethod
 import warnings
-import paramiko
 
 from pycloudlib.cloud import BaseCloud
 from pycloudlib.lxd.instance import LXDInstance
@@ -137,23 +135,6 @@ class _BaseLXD(BaseCloud):
                     instance.key_pair = self.key_pair
 
         return instance
-
-    def create_key_pair(self):
-        """Create and set a ssh key pair to be used by the lxd instance.
-
-        Args:
-            name: The name of the pycloudlib instance
-
-        Returns:
-            A tuple containing the public and private key created
-        """
-        key = paramiko.RSAKey.generate(4096)
-        priv_str = io.StringIO()
-
-        pub_key = "{} {}".format(key.get_name(), key.get_base64())
-        key.write_private_key(priv_str, password=None)
-
-        return pub_key, priv_str.getvalue()
 
     # pylint: disable=R0914,R0912,R0915
     def _prepare_command(


### PR DESCRIPTION
Currently, there is no way for the GCE cloud instance to create ssh keys to be used on the instances. We are now adding that possibility. Also, we are changing the user related to the ssh key from admin to ubuntu, to be consistent with the ssh behavior of other cloud instances