### PR TITLE
.travis.yml: install distro-info for cloud-init tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
           - pip install pytest
       script:
           - sudo apt-get remove --yes --purge lxd lxd-client
+          - sudo apt-get update -q
+          - sudo apt-get install -qqy distro-info
           - sudo rm -Rf /var/lib/lxd
           - sudo snap install lxd
           - sudo lxd init --auto


### PR DESCRIPTION
This is required for us to detect the version of the image under test,
which is required to skip tests which we expect to fail on that image.