### PR TITLE
azure: create_key_pair should strip CRLF from multi-line pub keys

### DIFF
--- a/examples/az.py
+++ b/examples/az.py
@@ -57,5 +57,6 @@ def demo():
 if __name__ == '__main__':
     # Avoid polluting the log with azure info
     logging.getLogger("adal-python").setLevel(logging.WARNING)
+    logging.getLogger("cli.azure.cli.core").setLevel(logging.WARNING)
     logging.basicConfig(level=logging.DEBUG)
     demo()

--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -633,7 +633,10 @@ class Azure(BaseCloud):
             resource_group_name=self.resource_group.name,
             ssh_public_key_name=key_name)
 
-        return ssh_call.public_key, ssh_call.private_key
+        # Azure's SDK returns multi-line DOS format for pubkeys.
+        # OpenSSH doesn't like this format and ignores it resulting in
+        # Unauthorized key errors. Issue: #88
+        return ssh_call.public_key.replace('\r\n', ''), ssh_call.private_key
 
     def list_keys(self):
         """List all ssh keys in the class resource group."""


### PR DESCRIPTION
pubkey content returned by Azure's SDK via
azure.mgmt.compute.ComputeManagementClient.ssh_public_keys.generate_key_pair
will contain CRLF \r\n at a 64 character line-width creating an invalid
ssh-rsa pub key format.

ssh-rsa <pub_key_content_part1>\r\n<pub_key_content_part2>\r\n<etc>

OpenSSH doesn't like this which results in ssh Unauthorized errors when
trying to ssh using your now local/invalid public_key.

Fixes: #88


# testing steps

To test:
* failure path without this PR
   ```bash
tox -e pylint
.tox/pylint/bin/python3 example/az.py    # get Unauthorized errors
cat pub_test.pem  # see newlines in ssh-rsa content at 64 char width
```

* success path use this PR
 ```bash
tox -r -e pylint
.tox/pylint/bin/python3 example/az.py
cat pub_test.pem # see a single line with ssh-rsa content
```