### PR TITLE
Fix regex that extracts release from image id

### DIFF
--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -581,7 +581,7 @@ class LXDVirtualMachine(_BaseLXD):
         release_regex = (
             "(.*ubuntu.*(?P<release>(" +
             "|".join(UBUNTU_RELEASE_VERSION_MAP) + "|" +
-            "|".join(UBUNTU_RELEASE_VERSION_MAP.values()) +
+            "|".join(UBUNTU_RELEASE_VERSION_MAP.values()).replace(".", "\\.") +
             ")).*)"
         )
         ubuntu_match = re.match(release_regex, image_id)

--- a/pycloudlib/lxd/tests/test_cloud.py
+++ b/pycloudlib/lxd/tests/test_cloud.py
@@ -94,6 +94,10 @@ class TestExtractReleaseFromImageId:
             ("images:ubuntu/16.04/cloud", "xenial"),
             ("ubuntu-daily:bionic", "bionic"),
             ("ubuntu:focal", "focal"),
+            (
+                "local:ubuntu-behave-image-build--vm-focal1610458-snapshot",
+                "focal"
+            ),
         ),
     )
     def test_extract_release_from_non_hashed_image_id(


### PR DESCRIPTION
On LXD, we use a regex to extract the ubuntu release from a image id. We try to find either the base release
name on the image id, like focal, or the version number, like 20.4. However, if the image id has a timestamp on it we could accidentally match the timestamp value instead of a valid version string. The reason for that is because
we are not escaping the dot part of the version string.

For example, for this image id:
`local:ubuntu-behave-image-build--vm-focal1610458065934836-snapshot`

Using the following regex:
`(.*ubuntu.*(?P<release>(focal|bionic|xenial|20\.04|18\.04|16\.04)).*)`

We are matching the timestamp part `16104` 