### PR TITLE
Set service account email for gce instance

### DIFF
--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -27,7 +27,7 @@ class GCE(BaseCloud):
 
     def __init__(
         self, tag, timestamp_suffix=True, credentials_path=None, project=None,
-        region="us-west2", zone="a"
+        region="us-west2", zone="a", service_account_email=None
     ):
         """Initialize the connection to GCE.
 
@@ -39,6 +39,8 @@ class GCE(BaseCloud):
             project: GCE project
             region: GCE region
             zone: GCE zone
+            service_account_email: service account to bind launched
+                                   instances to
         """
         super().__init__(tag, timestamp_suffix)
         self._log.debug('logging into GCE')
@@ -59,6 +61,7 @@ class GCE(BaseCloud):
         self.region = region
         self.zone = '%s-%s' % (region, zone)
         self.instance_counter = count()
+        self.service_account_email = service_account_email
 
     def _find_image(self, release, daily, arch='amd64'):
         images = self._image_list(release, daily, arch)
@@ -178,6 +181,13 @@ class GCE(BaseCloud):
                 }]
             },
         }
+
+        if self.service_account_email:
+            config["serviceAccounts"] = [
+                {
+                    "email": self.service_account_email
+                }
+            ]
 
         if user_data:
             user_metadata = {


### PR DESCRIPTION
When we are launching an image, we do not bind it to a service account, even if we are using a service account credential to launch the images. This is problematic because some of our vms need that to work properly. For example, the recent gcp pro machines requires that bind to allow uaclient to auto-attach on them. To fix that, we are now performing that bind if the user provides a service_account_email to the gce client.

@OddBloke I think this is a less restrictive approach than the one I had before