### PR TITLE
align GCE and Oracle launch wait behaviour with other clouds

### DIFF
--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -233,7 +233,11 @@ class GCE(BaseCloud):
             result['networkInterfaces'][0]['accessConfigs'][0]['natIP']
         )
 
-        return self.get_instance(result['id'], name=result['name'])
+        instance = self.get_instance(result['id'], name=result['name'])
+        if wait:
+            instance.wait()
+
+        return instance
 
     def snapshot(self, instance: GceInstance, clean=True, **kwargs):
         """Snapshot an instance and generate an image from it.

--- a/pycloudlib/oci/cloud.py
+++ b/pycloudlib/oci/cloud.py
@@ -204,13 +204,15 @@ class OCI(BaseCloud):
 
         instance_data = self.compute_client.launch_instance(
             instance_details).data
+        instance_data = wait_till_ready(
+            func=self.compute_client.get_instance,
+            current_data=instance_data,
+            desired_state='RUNNING',
+        )
+        instance = self.get_instance(instance_data.id)
         if wait:
-            instance_data = wait_till_ready(
-                func=self.compute_client.get_instance,
-                current_data=instance_data,
-                desired_state='RUNNING',
-            )
-        return self.get_instance(instance_data.id)
+            instance.wait()
+        return instance
 
     def snapshot(self, instance, clean=True, name=None):
         """Snapshot an instance and generate an image from it.


### PR DESCRIPTION
GCE simply had a bug: it didn't call `instance.wait()`.

OCI's behaviour is changed somewhat: we now unconditionally wait for the instance to be `RUNNING` and `wait=True` controls whether `instance.wait()` is called.