### PR TITLE
oci/gce: only perform cloud-native wait in launch if wait=True

### DIFF
--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -220,8 +220,6 @@ class GCE(BaseCloud):
         ).execute()
         raise_on_error(operation)
 
-        self._wait_for_operation(operation, operation_type='zone')
-
         result = self.compute.instances().get(
             project=self.project,
             zone=self.zone,
@@ -229,12 +227,9 @@ class GCE(BaseCloud):
         ).execute()
         raise_on_error(result)
 
-        self._log.info(
-            result['networkInterfaces'][0]['accessConfigs'][0]['natIP']
-        )
-
         instance = self.get_instance(result['id'], name=result['name'])
         if wait:
+            self._wait_for_operation(operation, operation_type='zone')
             instance.wait()
 
         return instance

--- a/pycloudlib/oci/cloud.py
+++ b/pycloudlib/oci/cloud.py
@@ -204,13 +204,13 @@ class OCI(BaseCloud):
 
         instance_data = self.compute_client.launch_instance(
             instance_details).data
-        instance_data = wait_till_ready(
-            func=self.compute_client.get_instance,
-            current_data=instance_data,
-            desired_state='RUNNING',
-        )
         instance = self.get_instance(instance_data.id)
         if wait:
+            wait_till_ready(
+                func=self.compute_client.get_instance,
+                current_data=instance_data,
+                desired_state='RUNNING',
+            )
             instance.wait()
         return instance
 


### PR DESCRIPTION
I previously made OCI's wait=True behaviour consistent with GCE, but
that means they are inconsistent with the other clouds supported by
pycloudlib.  This commit aligns their behaviour with the other clouds.

Specifically, the "wait for instance start" calls made to the cloud are
no longer unconditional, and instead are only executed if wait=True
before instance.wait() is called.