### PR TITLE
oci: fix API call broken in oci 2.18.0

### DIFF
--- a/pycloudlib/oci/cloud.py
+++ b/pycloudlib/oci/cloud.py
@@ -180,7 +180,7 @@ class OCI(BaseCloud):
         vcn_id = self.network_client.list_vcns(
             self.compartment_id).data[0].id
         subnet = self.network_client.list_subnets(
-            self.compartment_id, vcn_id).data[0]
+            self.compartment_id, vcn_id=vcn_id).data[0]
         subnet_id = subnet.id
         availability_domain = subnet.availability_domain
 


### PR DESCRIPTION
Per their changelog[0], list_subnets went from taking `vcn_id`
positionally to taking it as a keyword argument: this commit follows
that.

[0] https://github.com/oracle/oci-python-sdk/blob/master/CHANGELOG.rst#breaking-11

Fixes: #106