### PR TITLE
lxd/instance: use SSH by default, allow switching to `exec`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
   include:
     - name: run-lxd-example
       install:
+          # Generate an SSH key to connect to test instances
+          - ssh-keygen -N "" -f ~/.ssh/id_rsa
           - pip install -r requirements.txt
       script:
           - sudo apt-get remove --yes --purge lxd lxd-client
@@ -22,6 +24,8 @@ matrix:
           - sg lxd -c "python examples/lxd.py"
     - name: run-cloudinit-integration-tests
       install:
+          # Generate an SSH key to connect to test instances
+          - ssh-keygen -N "" -f ~/.ssh/id_rsa
           - pip install -r requirements.txt
           - pip install pytest
       script:

--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -13,7 +13,7 @@ class LXDInstance(BaseInstance):
     _type = 'lxd'
     _is_vm = None
 
-    def __init__(self, name, key_pair=None):
+    def __init__(self, name, key_pair=None, execute_via_ssh=True):
         """Set up instance.
 
         Args:
@@ -23,6 +23,7 @@ class LXDInstance(BaseInstance):
         super().__init__(key_pair=key_pair)
 
         self._name = name
+        self.execute_via_ssh = execute_via_ssh
 
     def __repr__(self):
         """Create string representation for class."""
@@ -30,7 +31,7 @@ class LXDInstance(BaseInstance):
 
     def _run_command(self, command, stdin):
         """Run command in the instance."""
-        if self.key_pair:
+        if self.execute_via_ssh:
             return super()._run_command(command, stdin)
 
         base_cmd = [

--- a/pycloudlib/lxd/tests/test_instance.py
+++ b/pycloudlib/lxd/tests/test_instance.py
@@ -1,0 +1,22 @@
+"""Tests for pycloudlib.lxd.instance."""
+from unittest import mock
+
+from pycloudlib.lxd.instance import LXDInstance
+
+
+class TestExecute:
+    """Tests covering pycloudlib.lxd.instance.Instance.execute."""
+
+    def test_all_rcs_acceptable_when_using_exec(self):
+        """Test that we invoke util.subp with rcs=None for exec calls.
+
+        rcs=None means that we will get a Result object back for all return
+        codes, rather than an exception for non-zero return codes.
+        """
+        instance = LXDInstance(None)
+        with mock.patch("pycloudlib.lxd.instance.subp") as m_subp:
+            instance.execute("some_command")
+        assert 1 == m_subp.call_count
+        args, kwargs = m_subp.call_args
+        assert "exec" in args[0]
+        assert kwargs.get("rcs", mock.sentinel.not_none) is None

--- a/pycloudlib/lxd/tests/test_instance.py
+++ b/pycloudlib/lxd/tests/test_instance.py
@@ -13,7 +13,7 @@ class TestExecute:
         rcs=None means that we will get a Result object back for all return
         codes, rather than an exception for non-zero return codes.
         """
-        instance = LXDInstance(None)
+        instance = LXDInstance(None, execute_via_ssh=False)
         with mock.patch("pycloudlib.lxd.instance.subp") as m_subp:
             instance.execute("some_command")
         assert 1 == m_subp.call_count

--- a/pycloudlib/tests/test_instance.py
+++ b/pycloudlib/tests/test_instance.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pytest
 
 from pycloudlib.instance import BaseInstance
-from pycloudlib.lxd.instance import LXDInstance
 from pycloudlib.result import Result
 
 # Disable this pylint check as fixture usage incorrectly triggers it:
@@ -19,36 +18,6 @@ def concrete_instance_cls():
     """
     with mock.patch.object(BaseInstance, "__abstractmethods__", set()):
         yield BaseInstance
-
-
-class TestExecute:
-    """Tests covering pycloudlib.instance.Instance.execute.
-
-    TODO: There are elements of `execute` which could be refactored onto the
-          relevant subclasses.  Some of these tests should move along with that
-          refactor.
-    """
-
-    @pytest.mark.parametrize(
-        "instance_cls,cloud_name",
-        (
-            (LXDInstance, "lxd"),
-        ),
-    )
-    def test_all_rcs_acceptable(self, instance_cls, cloud_name):
-        """Test that we invoke util.subp with rcs=None.
-
-        rcs=None means that we will get a Result object back for all return
-        codes, rather than an exception for non-zero return codes.
-        """
-        instance = instance_cls(None)
-        with mock.patch(
-            "pycloudlib.{}.instance.subp".format(cloud_name)
-        ) as m_subp:
-            instance.execute("some_command")
-        assert 1 == m_subp.call_count
-        _args, kwargs = m_subp.call_args
-        assert kwargs.get("rcs", mock.sentinel.not_none) is None
 
 
 class TestWait:


### PR DESCRIPTION
Analysis performed (and captured in #112) indicates that accessing LXD
instances via SSH rather than via `lxc exec` leads to faster test
execution, and also brings LXD's default behaviour in line with the
default behaviour of other clouds.

This commit introduces a `execute_via_ssh` parameter and instance
variable, which are used by `execute()` to determine whether to connect
to the instance via SSH, or use `lxc exec`.  The default value of
`execute_via_ssh` is `True`.

(Prior to this commit, we would execute via SSH but only if we had a key
manually set against the instance, leading to inconsistencies in
behaviour depending on local configuration.  This also addresses that.)

Fixes: #112