### PR TITLE
pycloudlib: increase a variety of retry frequencies

### DIFF
--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -375,7 +375,7 @@ class BaseInstance(ABC):
         test_instance_command = "whoami"
         result = self.execute(test_instance_command)
         if result.failed:
-            retries = 10
+            retries = 100
             while retries:
                 result = self.execute(test_instance_command)
 
@@ -383,7 +383,7 @@ class BaseInstance(ABC):
                     break
 
                 retries -= 1
-                time.sleep(10)
+                time.sleep(1)
 
         if result.failed:
             raise OSError(

--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -337,7 +337,7 @@ class BaseInstance(ABC):
                 last_exception, self.username, self.ip, self.port,
                 end - time.time()
             )
-            time.sleep(10)
+            time.sleep(1)
 
         self._log.error('Failed ssh connection to %s@%s:%s after 10 minutes',
                         self.username, self.ip, self.port)

--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -73,7 +73,7 @@ class LXDInstance(BaseInstance):
             IP address assigned to instance.
 
         """
-        retries = 5
+        retries = 150
 
         while retries != 0:
             command = 'lxc list {} -c 4 --format csv'.format(self.name)
@@ -83,7 +83,7 @@ class LXDInstance(BaseInstance):
                 break
 
             retries -= 1
-            time.sleep(20)
+            time.sleep(1)
 
         ip_address = result.split()[0]
         return ip_address

--- a/pycloudlib/tests/test_instance.py
+++ b/pycloudlib/tests/test_instance.py
@@ -52,14 +52,14 @@ class TestWait:
         expected_msg = "{}\n{}".format(
             "Instance can't be reached", "Failed to execute whoami command"
         )
-        expected_call_args = [mock.call("whoami")] * 11
+        expected_call_args = [mock.call("whoami")] * 101
 
         with pytest.raises(OSError) as excinfo:
             instance.wait()
 
         assert expected_msg == str(excinfo.value)
         assert expected_call_args == m_execute.call_args_list
-        assert m_sleep.call_count == 10
+        assert m_sleep.call_count == 100
 
 
 class TestWaitForCloudinit:


### PR DESCRIPTION
When investigating the relative performance of execution methods for #114, I found that a lot of our slow launch speeds were due to long sleeps between retries. This PR tweaks a variety of them, and fixes #111 as well.