### PR TITLE
Update lxc-setup script on lxd vm instances

### DIFF
--- a/pycloudlib/lxd/defaults.py
+++ b/pycloudlib/lxd/defaults.py
@@ -21,8 +21,7 @@ LXC_SETUP_VENDORDATA = textwrap.dedent(
               ICAgIFZJUlQ9JChzeXN0ZW1kLWRldGVjdC12aXJ0KQogICAgY2FzZSAkVklSVCBpbgogICAgICAg
               IHFlbXV8a3ZtKQogICAgICAgICAgICAoY2QgL3J1bi9seGRhZ2VudC8gJiYgLi9pbnN0YWxsLnNo
               KQogICAgICAgICAgICB1bW91bnQgL3J1bi9seGRhZ2VudAogICAgICAgICAgICBzeXN0ZW1jdGwg
-              c3RhcnQgbHhkLWFnZW50LTlwIGx4ZC1hZ2VudAogICAgICAgICAgICA7OwogICAgICAgICopCiAg
-              ICBlc2FjCmZpCg==
+              c3RhcnQgbHhkLWFnZW50CiAgICAgICAgICAgIDs7CiAgICAgICAgKikKICAgIGVzYWMKZmkK
    """
 )
 


### PR DESCRIPTION
When we create Xenial and Bionic lxd vm instances through pycloudlib, we need to provide a script to install the lxd-agent
on those machines. Recently, one of the services that was being started in this script was dropped from lxd, lxd-agent-9p. We are
now updating the script to remove references to that service.

This is the new script being used:
```sh
#!/bin/sh
if ! grep lxd_config /proc/mounts; then
    mkdir -p /run/lxdagent
    mount -t 9p config /run/lxdagent
    VIRT=$(systemd-detect-virt)
    case $VIRT in
        qemu|kvm)
            (cd /run/lxdagent/ && ./install.sh)
            umount /run/lxdagent
            systemctl start lxd-agent
            ;;
        *)
    esac
fi
```

And we can see that lxd has dropped support for the `lxd-agent-9p` service on this commit:
https://github.com/lxc/lxd/commit/2d013dfbeb4d10575989ab07e0a69022a6f9aa0b