### PR TITLE
lxd: pass SSH keys as meta-data

### DIFF
--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -1,6 +1,5 @@
 # This file is part of pycloudlib. See LICENSE file for license information.
 """LXD Cloud type."""
-import textwrap
 from abc import abstractmethod
 import warnings
 
@@ -149,21 +148,10 @@ class _BaseLXD(BaseCloud):
             cmd.append(name)
 
         if self.key_pair:
-            ssh_user_data = textwrap.dedent(
-                """\
-                ssh_authorized_keys:
-                    - {}
-                """.format(self.key_pair.public_key_content)
+            metadata = "public-keys: {}".format(
+                self.key_pair.public_key_content
             )
-
-            if user_data:
-                user_data += "\n{}".format(ssh_user_data)
-
-            if "user.user-data" in config_dict:
-                config_dict["user.user-data"] += "\n{}".format(ssh_user_data)
-
-            if not user_data and "user.user-data" not in config_dict:
-                user_data = "#cloud-config\n{}".format(ssh_user_data)
+            config_dict["user.meta-data"] = metadata
 
         if ephemeral:
             cmd.append('--ephemeral')


### PR DESCRIPTION
Instead of merging them into whatever user-data is specified by the
pycloudlib consumer: this has lead to issues when intentionally invalid
user-data is specified (because the SSH keys are ignored), and would
also cause issues if the consumer's user-data specified its own
ssh_authorized_keys (because they would be overriden).

Fixes: #98