### PR TITLE
Support 'instance_type' for Azure instances

### DIFF
--- a/examples/az.py
+++ b/examples/az.py
@@ -40,6 +40,7 @@ def demo():
 
     instance = client.launch(
         image_id=image_id,
+        instance_type='Standard_DS2_v2',  # default is Standard_DS1_v2
         user_data=cloud_config
     )
 


### PR DESCRIPTION
Azure was the only cloud that didn't include `instance_type` in it's launch.

Note that I DIDN'T put it at the end to keep as to keep it consistent with the other launch APIs. If people were passing args in a particular order to Azure launch, this will break them.