### PR TITLE
Drop support for xenial vstock image

### DIFF
--- a/pycloudlib/lxd/defaults.py
+++ b/pycloudlib/lxd/defaults.py
@@ -3,7 +3,7 @@
 import textwrap
 
 
-LXC_PROFILE_VERSION = "v1"
+LXC_PROFILE_VERSION = "v2"
 
 
 # For Xenial and Bionic vendor-data required to setup lxd-agent in a vm
@@ -12,7 +12,6 @@ LXC_SETUP_VENDORDATA = textwrap.dedent(
     config:
       user.vendor-data: |
         #cloud-config
-        {custom_cfg}
         write_files:
         - path: /var/lib/cloud/scripts/per-once/setup-lxc.sh
           encoding: b64
@@ -48,7 +47,7 @@ VM_PROFILE_TMPL = textwrap.dedent(
 
 
 def _make_vm_profile(
-    series: str, *, install_agent: bool, install_ssh: bool = False
+    series: str, *, install_agent: bool
 ) -> str:
     config_device = ""
     vendordata = "config: {}"
@@ -56,15 +55,14 @@ def _make_vm_profile(
         # We need to mount the config drive so that cloud-init finds the
         # vendor-data instructing it to install the agent
         config_device = "config: {source: cloud-init:config, type: disk}"
-        custom_cfg = "packages: [openssh-server]" if install_ssh else ""
-        vendordata = LXC_SETUP_VENDORDATA.format(custom_cfg=custom_cfg)
+        vendordata = LXC_SETUP_VENDORDATA
     return VM_PROFILE_TMPL.format(
         config_device=config_device, series=series, vendordata=vendordata
     )
 
 
 base_vm_profiles = {
-    "xenial": _make_vm_profile("xenial", install_agent=True, install_ssh=True),
+    "xenial": _make_vm_profile("xenial", install_agent=True),
     "bionic": _make_vm_profile("bionic", install_agent=True),
     "focal": _make_vm_profile("focal", install_agent=False),
     "groovy": _make_vm_profile("groovy", install_agent=False),

--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -13,7 +13,9 @@ class LXDInstance(BaseInstance):
     _type = 'lxd'
     _is_vm = None
 
-    def __init__(self, name, key_pair=None, execute_via_ssh=True):
+    def __init__(
+        self, name, key_pair=None, execute_via_ssh=True, series=None
+    ):
         """Set up instance.
 
         Args:
@@ -24,6 +26,7 @@ class LXDInstance(BaseInstance):
 
         self._name = name
         self.execute_via_ssh = execute_via_ssh
+        self.series = series
 
     def __repr__(self):
         """Create string representation for class."""
@@ -333,3 +336,24 @@ class LXDInstance(BaseInstance):
                 return
             time.sleep(1)
         raise TimeoutError
+
+
+class LXDVirtualMachineInstance(LXDInstance):
+    """LXD Virtual Machine backed instance."""
+
+    def _run_command(self, command, stdin):
+        """Run command in the instance."""
+        if self.execute_via_ssh:
+            return super()._run_command(command, stdin)
+
+        if self.series == "xenial":
+            msg = (
+                "Many xenial images do not support executing commands"
+                " via exec due to missing kernel support: you may see"
+                " unavoidable failures.\nSee"
+                " https://github.com/canonical/pycloudlib/issues/132 for"
+                " details."
+            )
+            self._log.warning(msg)
+
+        return super()._run_command(command, stdin)

--- a/pycloudlib/lxd/tests/test_defaults.py
+++ b/pycloudlib/lxd/tests/test_defaults.py
@@ -19,6 +19,13 @@ class TestLXDProfilesWereNotModified:
             "focal": "9ce4202e39d98c1499e3bce3c144e14f",
             "groovy": "05b1582d39237fb2d1b55c8782982bfd",
             "hirsute": "1f3851328bec6253f51b1f1dc9bcbf55",
+        },
+        "v2": {
+            "xenial": "c4f83c97c2f39a39f1e997aa33e4bb66",
+            "bionic": "0e35f88aa29c66374fbd9fe3b4a36257",
+            "focal": "9ce4202e39d98c1499e3bce3c144e14f",
+            "groovy": "05b1582d39237fb2d1b55c8782982bfd",
+            "hirsute": "1f3851328bec6253f51b1f1dc9bcbf55",
         }
     }
 
@@ -36,4 +43,6 @@ class TestLXDProfilesWereNotModified:
             ).hexdigest()
             profile_md5sum = profiles_md5sum[series]
 
+            print(series)
+            print(current_profile_md5sum)
             assert profile_md5sum == current_profile_md5sum

--- a/pycloudlib/lxd/tests/test_instance.py
+++ b/pycloudlib/lxd/tests/test_instance.py
@@ -1,7 +1,7 @@
 """Tests for pycloudlib.lxd.instance."""
 from unittest import mock
 
-from pycloudlib.lxd.instance import LXDInstance
+from pycloudlib.lxd.instance import LXDInstance, LXDVirtualMachineInstance
 
 
 class TestExecute:
@@ -20,3 +20,28 @@ class TestExecute:
         args, kwargs = m_subp.call_args
         assert "exec" in args[0]
         assert kwargs.get("rcs", mock.sentinel.not_none) is None
+
+
+class TestVirtualMachineExecute:  # pylint: disable=W0212
+    """Tests covering pycloudlib.lxd.instance.LXDVirtualMachineInstance."""
+
+    @mock.patch("pycloudlib.lxd.instance.subp")
+    def test_exec_with_run_command_on_xenial_machine(
+        self,
+        _m_subp,
+        caplog
+    ):
+        """Test exec does not work with xenial vm."""
+        instance = LXDVirtualMachineInstance(
+            None, execute_via_ssh=False, series="xenial")
+
+        instance._run_command(["test"], None)
+        expected_msg = (
+            "Many xenial images do not support executing commands"
+            " via exec due to missing kernel support: you may see"
+            " unavoidable failures.\nSee"
+            " https://github.com/canonical/pycloudlib/issues/132 for"
+            " details."
+        )
+        assert expected_msg in caplog.messages
+        assert _m_subp.call_count == 1


### PR DESCRIPTION
Currently, LXD xenial virtual machines use a special image to allow supporting installing lxd-agent on the vm and
run commands with lxc exec. Since we are now running all the commands with ssh by default, we don't need to support that xenial image anymore. The implication now is that xenial vm will not be able to run lxc exec commands