### PR TITLE
Update naming convetion for LXD vm profiles

### DIFF
--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -9,7 +9,7 @@ from pycloudlib.cloud import BaseCloud
 from pycloudlib.lxd.instance import LXDInstance
 from pycloudlib.util import subp
 from pycloudlib.constants import LOCAL_UBUNTU_ARCH
-from pycloudlib.lxd.defaults import base_vm_profiles
+from pycloudlib.lxd.defaults import base_vm_profiles, LXC_PROFILE_VERSION
 
 
 class UnsupportedReleaseException(Exception):
@@ -604,7 +604,8 @@ class LXDVirtualMachine(_BaseLXD):
         """
         image_id = self._normalize_image_id(image_id)
         base_release = self._extract_release_from_image_id(image_id)
-        profile_name = "pycloudlib-vm-{}".format(base_release)
+        profile_name = "pycloudlib-vm-{}-{}".format(
+            base_release, LXC_PROFILE_VERSION)
 
         self.create_profile(
             profile_name=profile_name,

--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -70,7 +70,10 @@ class _BaseLXD(BaseCloud):
             profile_config: Config to be added to the new profile
             force: Force the profile creation if it already exists
         """
-        profile_list = subp(["lxc", "profile", "list"])
+        profile_yaml = subp(["lxc", "profile", "list", "--format", "yaml"])
+        profile_list = [
+            profile["name"] for profile in yaml.safe_load(profile_yaml)
+        ]
 
         if profile_name in profile_list and not force:
             msg = "The profile named {} already exists".format(profile_name)

--- a/pycloudlib/lxd/defaults.py
+++ b/pycloudlib/lxd/defaults.py
@@ -3,6 +3,9 @@
 import textwrap
 
 
+LXC_PROFILE_VERSION = "v1"
+
+
 # For Xenial and Bionic vendor-data required to setup lxd-agent in a vm
 LXC_SETUP_VENDORDATA = textwrap.dedent(
     """\

--- a/pycloudlib/lxd/tests/test_cloud.py
+++ b/pycloudlib/lxd/tests/test_cloud.py
@@ -18,7 +18,9 @@ class TestProfileCreation:
     @mock.patch("pycloudlib.lxd.cloud.subp")
     def test_create_profile_that_already_exists(self, m_subp):
         """Tests creating a profile that already exists."""
-        m_subp.return_value = ["test_profile"]
+        m_subp.return_value = """
+            - name: test_profile
+        """
         cloud = LXDContainer(tag="test")
 
         fake_stdout = io.StringIO()
@@ -31,7 +33,7 @@ class TestProfileCreation:
         expected_msg = "The profile named test_profile already exists"
         assert expected_msg in fake_stdout.getvalue().strip()
         assert m_subp.call_args_list == [
-            mock.call(["lxc", "profile", "list"])
+            mock.call(["lxc", "profile", "list", "--format", "yaml"])
         ]
 
     @mock.patch("pycloudlib.lxd.cloud.subp")
@@ -39,7 +41,9 @@ class TestProfileCreation:
         self, m_subp
     ):
         """Tests creating an existing profile with force parameter."""
-        m_subp.return_value = ["test_profile"]
+        m_subp.return_value = """
+            - name: test_profile
+        """
         cloud = LXDContainer(tag="test")
         profile_name = "test_profile"
         profile_config = "profile_config"
@@ -51,7 +55,7 @@ class TestProfileCreation:
         )
 
         assert m_subp.call_args_list == [
-            mock.call(["lxc", "profile", "list"]),
+            mock.call(["lxc", "profile", "list", "--format", "yaml"]),
             mock.call(["lxc", "profile", "delete", profile_name]),
             mock.call(["lxc", "profile", "create", profile_name]),
             mock.call(
@@ -65,9 +69,11 @@ class TestProfileCreation:
         self, m_subp
     ):
         """Tests creating a new profile."""
-        m_subp.return_value = ["other_profile"]
+        m_subp.return_value = """
+            - name: other_profile
+        """
         cloud = LXDContainer(tag="test")
-        profile_name = "test_profile"
+        profile_name = "other_profile_v1"
         profile_config = "profile_config"
 
         cloud.create_profile(
@@ -76,7 +82,7 @@ class TestProfileCreation:
         )
 
         assert m_subp.call_args_list == [
-            mock.call(["lxc", "profile", "list"]),
+            mock.call(["lxc", "profile", "list", "--format", "yaml"]),
             mock.call(["lxc", "profile", "create", profile_name]),
             mock.call(
                 ["lxc", "profile", "edit", profile_name],

--- a/pycloudlib/lxd/tests/test_defaults.py
+++ b/pycloudlib/lxd/tests/test_defaults.py
@@ -1,0 +1,39 @@
+"""Tests related to pycloudlib.lxd.defaults module."""
+import hashlib
+
+from pycloudlib.lxd.defaults import base_vm_profiles, LXC_PROFILE_VERSION
+
+
+class TestLXDProfilesWereNotModified:
+    """Test covering if profiles were not accidentally changed."""
+
+    # This dict represents a mapping between the profile version and the
+    # md5sum associated with it. Whenever we have a new profile release,
+    # we must add a new entry to it with the new checksums, not overriding
+    # the existing dict we have here. The rationale for that is to avoid
+    # us forgetting to bump the profile version when modifying it.
+    version_to_md5sum = {
+        "v1": {
+            "xenial": "350af6388522c8c28d8e00152fac98cc",
+            "bionic": "b79ba7ea46882d35e6d10b08c7531f6f",
+            "focal": "9ce4202e39d98c1499e3bce3c144e14f",
+            "groovy": "05b1582d39237fb2d1b55c8782982bfd",
+            "hirsute": "1f3851328bec6253f51b1f1dc9bcbf55",
+        }
+    }
+
+    def test_profiles_md5sum_was_not_changed(self):
+        """Test if the profiles md5sum still match.
+
+        This test will ensure that the current profile version
+        matches the md5sums we have stored for the profiles.
+        """
+        profiles_md5sum = self.version_to_md5sum[LXC_PROFILE_VERSION]
+
+        for series, current_profile in base_vm_profiles.items():
+            current_profile_md5sum = hashlib.md5(
+                current_profile.encode('utf-8')
+            ).hexdigest()
+            profile_md5sum = profiles_md5sum[series]
+
+            assert profile_md5sum == current_profile_md5sum


### PR DESCRIPTION
Currently, when we update a LXD vm profile we may have not see it reflected on subsequent runs because we do not generate a new profile if there is one with the same name on the system. To avoid that, we are now adding a version suffix to the profile name while also creating a md5sum test that will fail if we update the profile content but do not update the md5sum in the test.

PS: The way our test is structure does not prevent that a user may modify the profile, change the md5sums but do not bump the version name on the profile. However, I am proposing a guideline to incrementally add new profile version to the md5sum dict. I believe this documentation can help us reviewing future PRs that will change the profile. But if anyone has an idea to programmatically check that the version was bumped when a md5sum was modified, please let me know and I will implement it