### PR TITLE
doc: update recommonmark configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,18 +43,11 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
+    'recommonmark',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
-
-# The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-#
-source_suffix = ['.rst', '.md']
-source_parsers = {
-   '.md': 'recommonmark.parser.CommonMarkParser',
-}
 
 # The master toctree document.
 master_doc = 'index'


### PR DESCRIPTION
Per https://recommonmark.readthedocs.io/en/latest/, this is the
appropriate way to enable recommonmark's Markdown handling for Sphinx
versions newer than 1.3.