### PR TITLE
Add banner timeout for paramiko connect

### DIFF
--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -35,6 +35,7 @@ class BaseInstance(ABC):
         self.port = '22'
         self.username = 'ubuntu'
         self.connect_timeout = 60
+        self.banner_timeout = 60
 
     @property
     @abstractmethod
@@ -322,6 +323,7 @@ class BaseInstance(ABC):
                     hostname=self.ip,
                     port=int(self.port),
                     timeout=self.connect_timeout,
+                    banner_timeout=self.banner_timeout,
                     key_filename=self.key_pair.private_key_path,
                 )
                 self._ssh_client = client


### PR DESCRIPTION
We are observing that a lot of tests that use pycloudlib are failing to due errors reading SSH protocol banner. Since we
cannot consistently reproduce those errors, we believe this should be related to a timeout issue. To address that we are now setting
the banner_timeout variable when we run paramiko connect method.

As an example, here is one Jenkins test that is being affected by this issue:
https://jenkins.canonical.com/server-team-jenkins-private/blue/rest/organizations/jenkins/pipelines/github-ci/pipelines/ubuntu-advantage-client/branches/PR-1414/runs/6/nodes/128/steps/153/log/?start=0