### PR TITLE
lxd.ip: better instance name match and parsing of lxc ls output

### DIFF
--- a/pycloudlib/lxd/tests/test_instance.py
+++ b/pycloudlib/lxd/tests/test_instance.py
@@ -1,7 +1,11 @@
 """Tests for pycloudlib.lxd.instance."""
+import re
 from unittest import mock
 
+import pytest
+
 from pycloudlib.lxd.instance import LXDInstance, LXDVirtualMachineInstance
+from pycloudlib.result import Result
 
 
 class TestExecute:
@@ -69,3 +73,79 @@ class TestVirtualMachineXenialAgentOperations:  # pylint: disable=W0212
         instance.push_file("/some/file", "/some/local/file")
         assert self._missing_agent_msg in caplog.text
         assert m_subp.call_count == 1
+        expected_msg = (
+            "Many Xenial images do not support `lxc file push` due to missing"
+            " lxd-agent: you may see unavoidable failures.\n"
+            "See https://github.com/canonical/pycloudlib/issues/132 for"
+            " details."
+        )
+        assert expected_msg in caplog.messages
+        assert m_subp.call_count == 1
+
+
+class TestIP:
+    """Tests covering pycloudlib.lxd.instance.Instance.ip."""
+
+    @pytest.mark.parametrize(
+        "stdouts,stderr,return_code,sleeps,expected",
+        (
+             (
+                  ["unparseable"], "", 0, 150,
+                  TimeoutError(
+                      "Unable to determine IP address after 150 retries."
+                      " exit:0 stdout: unparseable stderr: "
+                  )
+             ),
+             (    # retry on non-zero exit code
+                  ["10.0.0.1 (eth0)"], "", 1, 150,
+                  TimeoutError(
+                      "Unable to determine IP address after 150 retries."
+                      " exit:1 stdout: 10.0.0.1 (eth0) stderr: "
+                  )
+             ),
+             (    # empty values will retry indefinitely
+                  [""], "", 0, 150,
+                  TimeoutError(
+                      "Unable to determine IP address after 150 retries."
+                      " exit:0 stdout:  stderr: "
+                  )
+             ),
+             (    # only retry until success
+                  ["unparseable", "10.69.10.5 (eth0)\n"], "", 0, 1,
+                  "10.69.10.5"
+             ),
+             (
+                   ["10.69.10.5 (eth0)\n"], "", 0, 0, "10.69.10.5"
+             ),
+        )
+    )
+    @mock.patch("pycloudlib.lxd.instance.time.sleep")
+    @mock.patch("pycloudlib.lxd.instance.subp")
+    def test_ip_parses_ipv4_output_from_lxc(
+        self, m_subp, m_sleep, stdouts, stderr, return_code, sleeps, expected
+    ):
+        """IPv4 output matches specific vm name from `lxc list`.
+
+        Errors are retried and result in TimeoutError on failure.
+        """
+        if len(stdouts) > 1:
+            m_subp.side_effect = [
+                Result(stdout=out, stderr=stderr, return_code=return_code)
+                for out in stdouts
+            ]
+        else:
+            m_subp.return_value = Result(
+                stdout=stdouts[0], stderr=stderr, return_code=return_code
+            )
+        instance = LXDInstance(name="my_vm")
+        lxc_mock = mock.call(
+            ["lxc", "list", "^my_vm$", "-c4", "--format", "csv"]
+        )
+        if isinstance(expected, Exception):
+            with pytest.raises(type(expected), match=re.escape(str(expected))):
+                instance.ip  # pylint: disable=pointless-statement
+            assert [lxc_mock] * sleeps == m_subp.call_args_list
+        else:
+            assert expected == instance.ip
+            assert [lxc_mock] * (1 + sleeps) == m_subp.call_args_list
+        assert sleeps == m_sleep.call_count


### PR DESCRIPTION
lxd.ip: better instance name match and parsing of lxc ls output

Use exact name matching via lxc ls "^<name>%" to avoid matching
multiple vms with common name prefix.

Add try/except blocked to handle, ignore and retry on unexpected
responses while lxc brings up the instance networking.

Add some logging for unparseable output so we can better handle
those cases if they result in irresolvable instance state.

Raise TimeoutError if our 150 retries are exhausted

Fixes: #129
