### PR TITLE
Drop trusty support for launching lxd instances

### DIFF
--- a/docs/clouds/azure.md
+++ b/docs/clouds/azure.md
@@ -47,8 +47,8 @@ Azure requires an SSH key to be uploaded before using it. See the SSH Key page f
 To find latest daily Azure image for a release of Ubuntu:
 
 ```python
-azure.daily_image('trusty')
-"Canonical:UbuntuServer:14.04.0-LTS",
+azure.daily_image('xenial')
+"Canonical:UbuntuServer:16.04-DAILY-LTS"
 ```
 
 The return Azure image can then be used for launching instances.

--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -19,7 +19,6 @@ class Azure(BaseCloud):
     _type = 'azure'
 
     UBUNTU_RELEASE = {
-        "trusty": "Canonical:UbuntuServer:14.04.0-LTS",
         "xenial": "Canonical:UbuntuServer:16.04-DAILY-LTS",
         "bionic": "Canonical:UbuntuServer:18.04-DAILY-LTS",
         "focal": "Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts",  # noqa: E501

--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -402,23 +402,5 @@ class BaseInstance(ABC):
     def _wait_for_cloudinit(self):
         """Wait until cloud-init has finished."""
         self._log.debug('_wait_for_cloudinit to complete')
-
-        result = self.execute("cloud-init status --help")
-        has_wait = "--wait" in result.stdout
-
-        if has_wait:
-            cmd = ["cloud-init", "status", "--wait", "--long"]
-        else:
-            # runlevel 'N 2' supports distros without recent cloud-init
-            # (e.g. trusty).
-            runlevel_result = (
-                '[ "$(runlevel)" = "N 2" ] && '
-                "[ -f /run/cloud-init/result.json ]"
-            )
-            cmd = (
-                "i=0; while [ $i -lt {} ] && i=$(($i+1)); do {} && exit 0;"
-                " sleep 1; done; exit 1".format(
-                    self.boot_timeout, runlevel_result
-                )
-            )
-        result = self.execute(cmd, description='waiting for start')
+        cmd = ["cloud-init", "status", "--wait", "--long"]
+        self.execute(cmd, description='waiting for start')

--- a/pycloudlib/lxd/tests/test_cloud.py
+++ b/pycloudlib/lxd/tests/test_cloud.py
@@ -7,8 +7,7 @@ import pytest
 import yaml
 
 from pycloudlib.lxd.cloud import (LXDContainer,
-                                  LXDVirtualMachine,
-                                  UnsupportedReleaseException)
+                                  LXDVirtualMachine)
 from pycloudlib.result import Result
 
 
@@ -174,23 +173,3 @@ class TestExtractReleaseFromImageId:
 
         if expected_release == "fallthrough":
             assert [mock.call(image_id)] == m__image_info.call_args_list
-
-
-class TestSearchForImage:
-    """Tests pycloudlib.lxd.cloud._search_for_image method."""
-
-    def test_trusty_image_not_supported_when_launching_vms(
-        self
-    ):  # pylint: disable=W0212
-        """Tests searching for trusty image for launching LXD vms."""
-        cloud = LXDVirtualMachine(tag="test")
-
-        with pytest.raises(UnsupportedReleaseException) as excinfo:
-            cloud._search_for_image(
-                remote="remote",
-                daily=False,
-                release="trusty",
-            )
-
-        assert "Release trusty is not supported for LXD vms" == str(
-            excinfo.value)


### PR DESCRIPTION
We have dropped the support for trusty in [ubuntu-advantage-client](https://github.com/canonical/ubuntu-advantage-client/pull/1611). Since this is the only project we are aware that had the need for trusty lxd support, we are dropping that support from pycloudlib.

PS: I have kept the trusty check on LXD VMs, to alert the user that a trusty vm cannot be launched, but I can drop this as well if needed