### PR TITLE
gce: raise IndexError if no image found

### DIFF
--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -83,11 +83,7 @@ class GCE(BaseCloud):
     def _find_image(self, release, daily, arch='amd64'):
         images = self._image_list(release, daily, arch)
 
-        image_id = None
-        try:
-            image_id = images[0]['id']
-        except IndexError:
-            Exception('No images found')
+        image_id = images[0]['id']
 
         return 'projects/ubuntu-os-cloud-devel/global/images/%s' % image_id
 


### PR DESCRIPTION
This matches the behaviour of other platforms, which raise either
IndexError or ValueError to indicate that no daily/release image has
been found.  This fixes specifying a non-default GCE image in
cloud-init's integration testing.

(This isn't ideal, of course, but this commit at least makes it
consistent.)