### PR TITLE
Make OCI's availability domain required (SC-59)

### DIFF
--- a/examples/base_api.py
+++ b/examples/base_api.py
@@ -81,6 +81,7 @@ ALL_CLOUDS = {
         'zone': 'a',
     },
     pycloudlib.OCI: {
+        'availability_domain': os.environ.get('AVAILABILITY_DOMAIN'),
         'compartment_id': os.environ.get('COMPARTMENT_ID')
     },
     pycloudlib.Openstack: {

--- a/examples/oci.py
+++ b/examples/oci.py
@@ -15,7 +15,7 @@ runcmd:
 """
 
 
-def demo(compartment_id):
+def demo(availability_domain, compartment_id):
     """Show example of using the OCI library.
 
     Connects to OCI and launches released image. Then runs
@@ -23,6 +23,7 @@ def demo(compartment_id):
     """
     client = pycloudlib.OCI(
         'Oracle test',
+        availability_domain=availability_domain,
         compartment_id=compartment_id,
     )
 
@@ -46,8 +47,9 @@ def demo(compartment_id):
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    if len(sys.argv) != 2:
-        print('Usage: oci.py <oracle_compartment_id>')
+    if len(sys.argv) != 3:
+        print('Usage: oci.py <availability_domain> <compartment_id>')
         sys.exit(1)
-    passed_compartment_id = sys.argv[1]
-    demo(passed_compartment_id)
+    passed_availability_domain = sys.argv[1]
+    passed_compartment_id = sys.argv[2]
+    demo(passed_availability_domain, passed_compartment_id)

--- a/pycloudlib/oci/cloud.py
+++ b/pycloudlib/oci/cloud.py
@@ -20,8 +20,8 @@ class OCI(BaseCloud):
     _type = 'oci'
 
     def __init__(
-        self, tag, timestamp_suffix=True, compartment_id=None,
-        availability_domain=None, config_path='~/.oci/config',
+        self, tag, *, availability_domain, timestamp_suffix=True,
+        compartment_id=None, config_path='~/.oci/config'
     ):
         """
         Initialize the connection to OCI.
@@ -40,6 +40,8 @@ class OCI(BaseCloud):
             config_path: Path of OCI config file
         """
         super().__init__(tag, timestamp_suffix)
+        self.availability_domain = availability_domain
+
         if not compartment_id:
             command = ['oci', 'iam', 'compartment', 'get']
             exception_text = (
@@ -56,10 +58,6 @@ class OCI(BaseCloud):
                 raise Exception(exception_text)
             compartment_id = json.loads(result.stdout)['data']['id']
         self.compartment_id = compartment_id
-
-        if not availability_domain:
-            raise ValueError('availability_domain must be specified')
-        self.availability_domain = availability_domain
 
         if not os.path.isfile(os.path.expanduser(config_path)):
             raise ValueError(

--- a/pycloudlib/oci/cloud.py
+++ b/pycloudlib/oci/cloud.py
@@ -20,7 +20,7 @@ class OCI(BaseCloud):
     _type = 'oci'
 
     def __init__(
-        self, tag, *, availability_domain, timestamp_suffix=True,
+        self, tag, timestamp_suffix=True, *, availability_domain,
         compartment_id=None, config_path='~/.oci/config'
     ):
         """


### PR DESCRIPTION
availability_domain used to be able to be inferred from the subnet.
Now it is required to be passed manually.
https://docs.oracle.com/en-us/iaas/tools/python/2.38.3/api/core/models/oci.core.models.Subnet.html#oci.core.models.Subnet.availability_domain

Fixes #138