### PR TITLE
Move SSH retry logic to boot wait method (SC-58)

### DIFF
--- a/pycloudlib/lxd/tests/test_instance.py
+++ b/pycloudlib/lxd/tests/test_instance.py
@@ -8,6 +8,45 @@ from pycloudlib.lxd.instance import LXDInstance, LXDVirtualMachineInstance
 from pycloudlib.result import Result
 
 
+class TestRestart:
+    """Tests covering pycloudlib.lxd.instance.Instance.restart."""
+
+    @pytest.mark.parametrize(
+        "wait,force,cmd",
+        (
+            (True, True, ["lxc", "restart", "my_vm", "--force"]),
+            (True, False, ["lxc", "restart", "my_vm"]),
+            # When wait is false, call shutdown and start
+            (False, False, []), (False, True, [])
+        )
+    )
+    @mock.patch("pycloudlib.lxd.instance.LXDInstance.start")
+    @mock.patch("pycloudlib.lxd.instance.LXDInstance.shutdown")
+    @mock.patch("pycloudlib.lxd.instance.LXDInstance.wait")
+    @mock.patch("pycloudlib.lxd.instance.subp")
+    def test_restart_calls_lxc_cmd_with_force_param(
+        self, m_subp, m_wait, m_shutdown, m_start, wait, force, cmd
+    ):
+        """When wait=True, honor force param on lxc restart cmdline.
+
+        When wait is False will wait on shutdown and not wait on start.
+        """
+        instance = LXDInstance(name="my_vm")
+        instance.restart(force=force, wait=wait)
+        if wait:
+            assert [mock.call(cmd)] == m_subp.call_args_list
+            assert 0 == m_shutdown.call_count
+            assert 0 == m_start.call_count
+            assert 1 == m_wait.call_count
+        else:
+            assert 0 == m_subp.call_count
+            assert [
+                mock.call(wait=True, force=force)
+            ] == m_shutdown.call_args_list
+            assert [mock.call(wait=wait)] == m_start.call_args_list
+            assert 0 == m_wait.call_count
+
+
 class TestExecute:
     """Tests covering pycloudlib.lxd.instance.Instance.execute."""
 

--- a/pycloudlib/oci/instance.py
+++ b/pycloudlib/oci/instance.py
@@ -99,6 +99,12 @@ class OciInstance(BaseInstance):
         Args:
             wait: wait for the instance to shutdown
         """
+        # Because it's like 1995 or something...
+        # But seriously, without a sync (or 5), if you power down too quickly
+        # after first boot, all the keys created in /etc/ssh will turn into
+        # zero-byte files and you'll be permanently kicked out of your
+        # instance with your only hope being serial console access.
+        self.execute('sync; sync; sync; sync; sync')
         self.compute_client.instance_action(self.instance_data.id, 'STOP')
         if wait:
             self.wait_for_stop()


### PR DESCRIPTION
List of changes are in the respective commits (please don't squash merge them). If this PR is approved I'll take care of getting PR commits getting squashed into the right commit.

In general, moved all the SSH retry logic to the wait for boot section. The connection timeout should take care of the random network blips.

I also provided a base method for restart. Every cloud that issued a restart signal then waited for boot (including the fancy ec2 implementation) had occasional reboot issues. Are there any situations we know of where we'd need to explicitly send a restart signal rather than just a shutdown then start?

I also fixed some cloud-specific boot issues.

