### PR TITLE
Run Pycloudlib CI GH action only on pull_request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Pycloudlib CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   tox:


### PR DESCRIPTION
Specifying `pull_request` will still build every time there is a new push to the pull request. When we specify `push`, we get double builds for every PR.