### PR TITLE
Sync OCI on both shutdown and restart (SC-120)

### DIFF
--- a/pycloudlib/oci/instance.py
+++ b/pycloudlib/oci/instance.py
@@ -83,12 +83,23 @@ class OciInstance(BaseInstance):
         if wait:
             self.wait_for_delete()
 
+    def _sync_filesystem(self):
+        """Sync the filesystem before powering down.
+
+        Without a sync, if you power down too quickly
+        after first boot, all the keys created in /etc/ssh will turn into
+        zero-byte files and you'll be permanently kicked out of your
+        instance with your only hope being serial console access.
+        """
+        self.execute('sync')
+
     def restart(self, wait=True, **kwargs):
         """Restart the instance.
 
         Args:
             wait: wait for the instance to be fully started
         """
+        self._sync_filesystem()
         self.compute_client.instance_action(self.instance_data.id, 'RESET')
         if wait:
             self.wait()
@@ -99,12 +110,7 @@ class OciInstance(BaseInstance):
         Args:
             wait: wait for the instance to shutdown
         """
-        # Because it's like 1995 or something...
-        # But seriously, without a sync (or 5), if you power down too quickly
-        # after first boot, all the keys created in /etc/ssh will turn into
-        # zero-byte files and you'll be permanently kicked out of your
-        # instance with your only hope being serial console access.
-        self.execute('sync; sync; sync; sync; sync')
+        self._sync_filesystem()
         self.compute_client.instance_action(self.instance_data.id, 'STOP')
         if wait:
             self.wait_for_stop()


### PR DESCRIPTION
Whoops, when I removed the "start/stop" commit on the timeout PR, I forgot to update OCI to also sync before restart.

Also updated the description to be slightly less aggressive :joy: 