### PR TITLE
Run Pycloudlib CI GH action on both 'push' and 'pull_request'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Pycloudlib CI
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   tox:


### PR DESCRIPTION
This reverts commit 79cdc8a832a82e82293ec2288e86b0d1b7374481.

When running CI on: [push, pull_request] and commits are pushed to a PR
there is the impression that CI runs twice, once for the "push" and once
because the PR got updated. This is actually not true as the run is not
the same:

 - The push-triggered CI run happens on the branch as it is;
 - The pull_request-triggered CI run happens on the *merge* of the PR
   to its target branch.

so the second is not really a duplicate. In particular in the pycloudlib
repository we didn't set the "Require branches to be up to date before
merging" GH option, so merges are not always quasi-fast-forwards, and the
two CI runs can differ.
