### PR TITLE
ec2: Increase console wait time to 5 minutes

### DIFF
--- a/pycloudlib/ec2/instance.py
+++ b/pycloudlib/ec2/instance.py
@@ -110,7 +110,7 @@ class EC2Instance(BaseInstance):
 
         """
         start = time.time()
-        while time.time() < start + 180:
+        while time.time() < start + 300:
             response = self._instance.console_output()
             try:
                 return response['Output']


### PR DESCRIPTION
We're still getting failures on ec2 due to console logs not being available. E.g., https://jenkins.ubuntu.com/server/view/cii-pytest/job/cloud-init-integration-ec2-focal-daily/5/console

I want to try upping the wait time to 5 minutes, and if that doesn't work, restricting the test to only run on LXD until we can fix what's wrong here.