### PR TITLE
Allow snapshot for LXD ephemeral instances (SC-321)

### DIFF
--- a/examples/lxd.py
+++ b/examples/lxd.py
@@ -34,6 +34,33 @@ def snapshot_instance():
     inst.delete(wait=False)
 
 
+def image_snapshot_instance(ephemeral_instance=False):
+    """Demonstrate image snapshot functionality.
+
+    Create an snapshot image from a running instance an show
+    how to launch a new instance based of this image snapshot
+    """
+    lxd = pycloudlib.LXDContainer('example-image-snapshot')
+    inst = lxd.launch(
+        name='pycloudlib-snapshot-base',
+        image_id=RELEASE,
+        ephemeral=ephemeral_instance
+    )
+    inst.execute("touch snapshot-test.txt")
+    print("Base instance output: {}".format(inst.execute("ls")))
+    snapshot_image = lxd.snapshot(instance=inst)
+
+    snapshot_inst = lxd.launch(
+        name="pycloudlib-snapshot-image",
+        image_id=snapshot_image,
+        ephemeral=ephemeral_instance
+    )
+    print("Snapshot instance output: {}".format(snapshot_inst.execute("ls")))
+
+    snapshot_inst.delete()
+    inst.delete()
+
+
 def modify_instance():
     """Demonstrate how to modify and interact with an instance.
 
@@ -224,6 +251,7 @@ def demo():
     launch_multiple()
     modify_instance()
     snapshot_instance()
+    image_snapshot_instance(ephemeral_instance=False)
     launch_virtual_machine()
 
 

--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -371,10 +371,11 @@ class LXDInstance(BaseInstance):
             snapshot_name: name to call snapshot
         """
         self.clean()
-        self.shutdown(wait=True)
         if snapshot_name is None:
             snapshot_name = '{}-snapshot'.format(self.name)
-        cmd = ['lxc', 'publish', self.name, '--alias', snapshot_name]
+        cmd = [
+            'lxc', 'publish', "--force", self.name, '--alias', snapshot_name
+        ]
 
         self._log.debug('Publishing snapshot %s', snapshot_name)
         subp(cmd)


### PR DESCRIPTION
During the snapshot call, we shutdown the base instance before creating the snapshot. This approach doesn't work for ephemeral instances, because they get deleted after the shutdown operation. We are now updating the snapshot function to allow ephemeral instances to be snapshot.

Fixes #159