### PR TITLE
gce: fallback to GOOGLE_CLOUD_PROJECT if project is not specified

### DIFF
--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -53,6 +53,8 @@ class GCE(BaseCloud):
 
         if project:
             os.environ["GOOGLE_CLOUD_PROJECT"] = str(project)
+        elif "GOOGLE_CLOUD_PROJECT" in os.environ:
+            project = os.environ["GOOGLE_CLOUD_PROJECT"]
         else:
             command = ['gcloud', 'config', 'get-value', 'project']
             exception_text = (


### PR DESCRIPTION
When initializing GCE fallback to the GOOGLE_APPLICATION_CREDENTIALS and
GOOGLE_CLOUD_PROJECT environment variables if credentials_path or
project are not specified.
