### PR TITLE
Pin pyparsing dependency (SC-520)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ INSTALL_REQUIRES = [
     "azure-cli-core >= 2.9.1",
     "knack >= 0.7.1",
     "python-openstackclient >= 5.2.1",
+    "pyparsing >= 2, < 3.0.0",
 
     # Simplestreams is not found on PyPi so pull from repo directly
     "python-simplestreams @ git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d",  # noqa


### PR DESCRIPTION
cloud-init integration tests are failing:
```
ImportError while loading conftest '/home/travis/build/canonical/cloud-init/tests/integration_tests/conftest.py'.
tests/integration_tests/conftest.py:13: in <module>
    from tests.integration_tests.clouds import (
tests/integration_tests/clouds.py:7: in <module>
    from pycloudlib import (
.tox/integration-tests-ci/lib/python3.6/site-packages/pycloudlib/__init__.py:8: in <module>
    from pycloudlib.gce.cloud import GCE
.tox/integration-tests-ci/lib/python3.6/site-packages/pycloudlib/gce/cloud.py:14: in <module>
    import googleapiclient.discovery
.tox/integration-tests-ci/lib/python3.6/site-packages/googleapiclient/discovery.py:42: in <module>
    import httplib2
.tox/integration-tests-ci/lib/python3.6/site-packages/httplib2/__init__.py:52: in <module>
    from . import auth
.tox/integration-tests-ci/lib/python3.6/site-packages/httplib2/auth.py:20: in <module>
    auth_param_name = token.copy().setName("auth-param-name").addParseAction(pp.downcaseTokens)
E   AttributeError: module 'pyparsing' has no attribute 'downcaseTokens'
ERROR: InvocationError for command /home/travis/build/canonical/cloud-init/.tox/integration-tests-ci/bin/python -m pytest --log-cli-level=INFO tests/integration_tests (exited with code 4)
___________________________________ summary ____________________________________
ERROR:   integration-tests-ci: commands failed
The command "sg lxd -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls *.deb)" tox -e integration-tests-ci'" exited with 1.
```

pyparsing API changed in 3.0.0: https://github.com/pyparsing/pyparsing/blob/master/CHANGES#L486 , but since this is being called from the google APIs, we can't update the usage of it.