### PR TITLE
Revert openstack pin and fix call site

### DIFF
--- a/pycloudlib/openstack/instance.py
+++ b/pycloudlib/openstack/instance.py
@@ -172,7 +172,6 @@ class OpenstackInstance(BaseInstance):
         """
         port = self.conn.network.create_port(
             network_id=self.network_id,
-            node_id=self.server.id
         )
         self.added_local_ports.append(port.id)
         interface = self.conn.compute.create_server_interface(

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ INSTALL_REQUIRES = [
     "azure-mgmt-compute >= 13.0.0, < 17",
     "azure-cli-core >= 2.9.1",
     "knack >= 0.7.1",
-    "python-openstackclient == 5.2.1",
+    "python-openstackclient >= 5.2.1",
     "pyparsing >= 2, < 3.0.0",
 
     # Simplestreams is not found on PyPi so pull from repo directly


### PR DESCRIPTION
```
Revert openstack pin and fix call site

In 85a22bd7 I pinned the openstack version because I thought a later
version of the API changed. In actuality, I was passing an unneeded
argument. Older versions of the API didn't raise on it, but newer
versions do, so revert the pin and fix the API call.
```

Notice that none of the openstack API versions we use have a "node_id":
https://docs.openstack.org/openstacksdk/victoria/user/resources/network/v2/port.html#openstack.network.v2.port.Port
https://docs.openstack.org/openstacksdk/wallaby/user/resources/network/v2/port.html#openstack.network.v2.port.Port
https://docs.openstack.org/openstacksdk/xena/user/resources/network/v2/port.html#openstack.network.v2.port.Port
https://docs.openstack.org/openstacksdk/latest/user/resources/network/v2/port.html#openstack.network.v2.port.Port

Tested locally using both `5.2.1` and `5.6.0` (latest).