### PR TITLE
docs: auto-generate the API docs (SC-656)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,7 +15,6 @@ help:
 
 build:
 	rm -rf source _build
-	sphinx-apidoc --module-first --separate --output-dir source/ ../pycloudlib
 	$(MAKE) html
 
 clean:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,9 @@
 #
 import os
 import sys
+
+from sphinx.ext import apidoc
+
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('..'))
 
@@ -178,6 +181,18 @@ def skip(app, what, name, obj, skip, options):
     return skip
 
 
+def run_apidoc(_):
+    """Runs sphinx-apidoc when building the documentation."""
+    apidoc.main([
+        "--module-first",
+        "--separate",
+        "--output-dir",
+        "source/",
+        "../pycloudlib"
+    ])
+
+
 def setup(app):
     """Add exception to autodoc's skip-member function."""
     app.connect("autodoc-skip-member", skip)
+    app.connect("builder-inited", run_apidoc)


### PR DESCRIPTION
In 49dbce2cac5b9682435ee58dfa902efff7e9ca68 , I removed the api-docs from version control thinking they get regenerated every readthedocs build. They do not (and were years out of date). This change lets us auto-generate the API docs during the readthedocs build.

Current API docs: https://pycloudlib.readthedocs.io/en/latest/api.html# (because I removed them :smile: )
Temporary API docs using this branch: https://pycloudlib.readthedocs.io/en/auto-apidoc/api.html
