### PR TITLE
lxd vm: wait up to 600s for the agent to come up

### DIFF
--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -484,7 +484,7 @@ class LXDInstance(BaseInstance):
         of processes isn't -1.
         """
         processes = -1
-        for _ in range(300):
+        for _ in range(600):
             try:
                 processes = int(
                     subp("lxc list -c N {} -f csv".format(self.name).split())


### PR DESCRIPTION
Apparently 300s are not enough when the host machine is busy, in
particular Bionic seems to be likely to hit the 300s timeout.
