### PR TITLE
azure: add jammy daily image support

### DIFF
--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -24,6 +24,7 @@ class Azure(BaseCloud):
         "focal": "Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts",  # noqa: E501
         "groovy": "Canonical:0001-com-ubuntu-server-groovy-daily:20_10-daily",
         "hirsute": "Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily",  # noqa: E501
+        "jammy": "Canonical:0001-com-ubuntu-server-hirsute-daily:22_04-daily",
     }
 
     def __init__(


### PR DESCRIPTION
Add missing Jammy image support for Azure.

Fixes Jenkins errors of the type
22:37:56 E           Message: Property id 'jammy' at path 'properties.storageProfile.imageReference.id' is invalid. Expect fully qualified resource Id that start with '/subscriptions/{subscriptionId}' or '/providers/{resourceProviderNamespace}/'.


And pycloudlib errors of 
`ValueError: No Ubuntu release image found for None. Expected one of: xenial bionic focal groovy hirsute`


To test:

1. setup ~/.config/pyclcoudlib.toml for the azure section based on `az ad sp create-for-rbac --sdk-auth`
2. Attempt to find a "jammy" daily image
```bash
tox -e pytest
echo > test.py <<EOF
import pycloudlib
import logging 

def doit():
    logging.basicConfig(level=logging.DEBUG)
    client = pycloudlib.Azure(tag="azure")
    print(client.daily_image(release="jammy"))

if __name__ == "__main__":
   doit()
EOF
```
     

