### PR TITLE
set max azure-cli-core version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ INSTALL_REQUIRES = [
     "azure-mgmt-resource >= 10.0.0, < 15",
     "azure-mgmt-network >= 11.0.0, < 16",
     "azure-mgmt-compute >= 13.0.0, < 17",
-    "azure-cli-core >= 2.9.1",
+    "azure-cli-core >= 2.9.1, < 2.21.0",
     "knack >= 0.7.1",
     "python-openstackclient >= 5.2.1",
     "toml == 0.10",


### PR DESCRIPTION
In the logs of a failed test:
```
21:50:41     def get_azure_cli_credentials(resource=None, with_tenant=False):
21:50:41         """Return Credentials and default SubscriptionID of current loaded profile of the CLI.
21:50:41     
21:50:41         *Disclaimer*: This method is not working for azure-cli-core>=2.21.0 (released in March 2021).
21:50:41         It is now recommended to authenticate using https://pypi.org/project/azure-identity/ and AzureCliCredential.
```

I think this "fix" will get our tests passing, but since this has been depreciated it looks like we'll eventually need to switch to azure-identity.  Alternatively we could add the azure-identity dependency and modifications right now, if preferred.