### PR TITLE
azure: fix cut-n-paste image issue

### DIFF
--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -24,7 +24,7 @@ class Azure(BaseCloud):
         "focal": "Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts",  # noqa: E501
         "groovy": "Canonical:0001-com-ubuntu-server-groovy-daily:20_10-daily",
         "hirsute": "Canonical:0001-com-ubuntu-server-hirsute-daily:21_04-daily",  # noqa: E501
-        "jammy": "Canonical:0001-com-ubuntu-server-hirsute-daily:22_04-daily",
+        "jammy": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts",  # noqa: E501
     }
 
     def __init__(


### PR DESCRIPTION
We don't expect to see hirsute in the image list for Jammy.
Also LTS images for Azure typically have -lts in image name
suffix.



## Test instructions
```bash
# validate the the jammy image publishing structure in azure
az image list --alls --publisher Canonical | tee azure.images
grep server-jammy  azure.images

# Validate we don't get image errors from Azure SDK on instance launch
cat >test.py <<EOF
import logging

import pycloudlib


def demo():
    client = pycloudlib.Azure(tag="azure")

    image_id = client.daily_image(release="jammy")
    instance = client.launch(
        image_id=image_id,
        instance_type="Standard_DS2_v2",  # default is Standard_DS1_v2
    )
    instance.delete()


if __name__ == "__main__":
    # Avoid polluting the log with azure info
    logging.getLogger("adal-python").setLevel(logging.WARNING)
    logging.getLogger("cli.azure.cli.core").setLevel(logging.WARNING)
    logging.basicConfig(level=logging.DEBUG)
    demo()
EOF
tox -e pytest
.tox/.testenv/bin/python3 test.py


# Expected failure before this PR:
# msrestazure.azure_exceptions.CloudError: Azure Error: PlatformImageNotFound
Message: The platform image 'Canonical:0001-com-ubuntu-server-hisute-daily:22_04-daily:latest' is not available. Verify that all fields in the storage profile are correct. For more details about storage profile information, please refer to https://aka.ms/storageprofile

# expect success with this PR
```