### PR TITLE
Stop using short options on "lxc list"

### DIFF
--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -487,7 +487,11 @@ class LXDInstance(BaseInstance):
         for _ in range(600):
             try:
                 processes = int(
-                    subp("lxc list -c N {} -f csv".format(self.name).split())
+                    subp(
+                        "lxc list --columns N {} --format csv".format(
+                            self.name
+                        ).split()
+                    )
                 )
             except ValueError:
                 pass


### PR DESCRIPTION
The '-f' flag is no longer available. Long options are better anyway
because they are more readable.
