### PR TITLE
Update Bionic LXD VM profile

### DIFF
--- a/pycloudlib/lxd/tests/test_defaults.py
+++ b/pycloudlib/lxd/tests/test_defaults.py
@@ -39,6 +39,15 @@ class TestLXDProfilesWereNotModified:
             "impish": "c2a4e4d6a9c16f73f2f79fe34d3f638f",
             "jammy": "7329f45a0a46be7a0e9f0acdb7e5908d",
         },
+        "v4": {
+            "xenial": "da94488cc93ebbb136c1f6830e6b9fcc",
+            "bionic": "3e4350a78bd0f086562bc264be9d715b",
+            "focal": "9ce4202e39d98c1499e3bce3c144e14f",
+            "groovy": "05b1582d39237fb2d1b55c8782982bfd",
+            "hirsute": "1f3851328bec6253f51b1f1dc9bcbf55",
+            "impish": "c2a4e4d6a9c16f73f2f79fe34d3f638f",
+            "jammy": "7329f45a0a46be7a0e9f0acdb7e5908d",
+        },
     }
 
     @pytest.mark.parametrize("series", base_vm_profiles.keys())


### PR DESCRIPTION
Currently, there is a known [regression](https://github.com/lxc/distrobuilder/commit/04f32caf6f0e874e856ef8fc88f1c85275211dfb) that prevents us from installing the lxd-agent on Bionic VMs. Since we need
the service running to boot the VM through pycloudlib, we are providing a temporary solution until that issue is properly fixed
on LXD