### PR TITLE
Bump EC2 instance type (SC-924)

### DIFF
--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -172,7 +172,7 @@ class EC2(BaseCloud):
     def launch(
         self,
         image_id,
-        instance_type="t2.micro",
+        instance_type="t3.micro",  # Using nitro instance for IPv6
         user_data=None,
         wait=True,
         vpc=None,


### PR DESCRIPTION
# Proposed commit message
```
Bump EC2 instance type

Updates the default ec2 instance type to t3.micro as it supports
IPv6 metadata while also being faster and cheaper than t2.
```

