### PR TITLE
config: expand environment variables in paths (SC-941)

### DIFF
--- a/pycloudlib/cloud.py
+++ b/pycloudlib/cloud.py
@@ -35,11 +35,15 @@ class BaseCloud(ABC):
 
         user = getpass.getuser()
         self.key_pair = KeyPair(
-            public_key_path=os.path.expanduser(
-                self.config.get("public_key_path", f"~{user}/.ssh/id_rsa.pub")
+            public_key_path=os.path.expandvars(
+                os.path.expanduser(
+                    self.config.get(
+                        "public_key_path", f"~{user}/.ssh/id_rsa.pub"
+                    )
+                )
             ),
-            private_key_path=os.path.expanduser(
-                self.config.get("private_key_path", "")
+            private_key_path=os.path.expandvars(
+                os.path.expanduser(self.config.get("private_key_path", ""))
             ),
             name=self.config.get("key_name", user),
         )

--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -64,8 +64,8 @@ class GCE(BaseCloud):
                 "GOOGLE_APPLICATION_CREDENTIALS"
             ]
         elif "credentials_path" in self.config:
-            self.credentials_path = os.path.expanduser(
-                self.config["credentials_path"]
+            self.credentials_path = os.path.expandvars(
+                os.path.expanduser(self.config["credentials_path"])
             )
 
         credentials = get_credentials(self.credentials_path)

--- a/pycloudlib/gce/util.py
+++ b/pycloudlib/gce/util.py
@@ -32,7 +32,7 @@ def get_credentials(credentials_path):
 
     Try service account credentials first. If those fail, try the environment
     """
-    credentials_path = os.path.expanduser(credentials_path)
+    credentials_path = os.path.expandvars(os.path.expanduser(credentials_path))
     if credentials_path:
         try:
             return service_account.Credentials.from_service_account_file(

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     flake8==4.0.1
     flake8-docstrings==1.6.0
     pylint==2.12.2
-    black==21.12b0
+    black==22.3.0
     -rrequirements.txt
     -rtest-requirements.txt
 


### PR DESCRIPTION
config: expand environment variables in paths

This is particularly helpful in Jenkins where file credentials are put
in a random location which exposed via an environment variable, which
we can now specify in the toml config.
