### PR TITLE
Include Azure released images (SC-943)

### DIFF
--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -25,6 +25,7 @@ UBUNTU_RELEASE_IMAGES = {
     "bionic": "Canonical:UbuntuServer:18.04-LTS",
     "focal": "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2",
     "impish": "Canonical:0001-com-ubuntu-server-impish:21_10-gen2",
+    "jammy": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2",
 }
 
 

--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -460,14 +460,12 @@ class Azure(BaseCloud):
             )
 
     def _get_image(self, release, image_map):
-        release = image_map.get(release)
-        if release is None:
+        image_id = image_map.get(release)
+        if image_id is None:
             msg = "No Ubuntu image found for {}. Expected one of: {}"
-            raise ValueError(
-                msg.format(release, " ".join(UBUNTU_DAILY_IMAGES.keys()))
-            )
+            raise ValueError(msg.format(release, " ".join(image_map.keys())))
 
-        return release
+        return image_id
 
     def released_image(self, release):
         """Get the released image.


### PR DESCRIPTION
Previously, released_image() pointed to daily_image() on Azure. This
commit allows us to launch released images as well.

Fixes #96 