### PR TITLE
ec2 restart(): sleep less when checking if boot_id changed (SC-976)

### DIFF
--- a/pycloudlib/ec2/instance.py
+++ b/pycloudlib/ec2/instance.py
@@ -170,7 +170,7 @@ class EC2Instance(BaseInstance):
         current_boot_id = pre_reboot_boot_id
         self._instance.reboot()
         while current_boot_id == pre_reboot_boot_id:
-            time.sleep(5)
+            time.sleep(1)
             try:
                 self._log.debug("Reading the current boot_id.")
                 current_boot_id = self._get_boot_id()


### PR DESCRIPTION
The test is not expensive, we can lower the sleep interval.
This matters when gathering post-reboot metrics (e.g. time to first
successful ssh login).
