### PR TITLE
wait_for_execute(): wait up to 40 minutes (SC-977)

### DIFF
--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -403,9 +403,9 @@ class BaseInstance(ABC):
         self._log.debug("_wait_for_execute to complete")
         test_instance_command = "whoami"
 
-        # Wait 10 minutes before failing
+        # Wait 40 minutes before failing
         start = time.time()
-        end = start + 600
+        end = start + 40 * 60
         while time.time() < end:
             try:
                 result = self.execute(test_instance_command)
@@ -417,7 +417,7 @@ class BaseInstance(ABC):
 
         raise OSError(
             "{}\n{}".format(
-                "Instance can't be reached after 10 minutes. ",
+                "Instance can't be reached after 40 minutes. ",
                 "Failed to execute {} command".format(test_instance_command),
             )
         )

--- a/pycloudlib/tests/test_instance.py
+++ b/pycloudlib/tests/test_instance.py
@@ -49,10 +49,10 @@ class TestWait:
     ):
         """Test wait calls when execute command fails."""
         instance = concrete_instance_cls(key_pair=None)
-        m_time.side_effect = [1, 2, 600, 601]
+        m_time.side_effect = [1, 2, 40 * 60, 40 * 60 + 1]
         m_execute.return_value = Result(stdout="", stderr="", return_code=1)
         expected_msg = "{}\n{}".format(
-            "Instance can't be reached after 10 minutes. ",
+            "Instance can't be reached after 40 minutes. ",
             "Failed to execute whoami command",
         )
         expected_call_args = [mock.call("whoami")] * 2


### PR DESCRIPTION
AWS EC2 metal instances can take over 20 minutes to start or restart.
