### PR TITLE
Get latest console_log from ec2 (SC-982)

### DIFF
--- a/pycloudlib/ec2/instance.py
+++ b/pycloudlib/ec2/instance.py
@@ -110,7 +110,7 @@ class EC2Instance(BaseInstance):
         """
         start = time.time()
         while time.time() < start + 300:
-            response = self._instance.console_output()
+            response = self._instance.console_output(Latest=True)
             try:
                 return response["Output"]
             except KeyError:


### PR DESCRIPTION
# Commit msg
```
Get latest console_log from ec2

Without this, retrieving the console log can take up to 20 minutes.
Requires Nitro, but all of our ec2 instances already do.
```

See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Instance.console_output