### PR TITLE
Raise exception when no results from streams query (SC-996)

### DIFF
--- a/pycloudlib/cloud.py
+++ b/pycloudlib/cloud.py
@@ -205,4 +205,8 @@ class BaseCloud(ABC):
             keyring_path="/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg",
         )
 
-        return stream.query(filters)
+        result = stream.query(filters)
+        if not result:
+            raise ValueError(f"No images found matching filters: {filters}")
+
+        return result

--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -1,5 +1,6 @@
 # This file is part of pycloudlib. See LICENSE file for license information.
 """LXD Cloud type."""
+from contextlib import suppress
 import warnings
 from abc import abstractmethod
 
@@ -583,17 +584,14 @@ class LXDVirtualMachine(_BaseLXD):
         """
         if image_hash_key is not None:
             return super()._image_info(image_id, image_hash_key=image_hash_key)
-        kvm_image_info = super()._image_info(
-            image_id, image_hash_key=self.DISK_KVM_HASH_KEY
-        )
-        if kvm_image_info:
-            return kvm_image_info
-
-        uefi1_image_info = super()._image_info(
-            image_id, image_hash_key=self.DISK_UEFI1_KEY
-        )
-        if uefi1_image_info:
-            return uefi1_image_info
+        with suppress(ValueError):
+            return super()._image_info(
+                image_id, image_hash_key=self.DISK_KVM_HASH_KEY
+            )
+        with suppress(ValueError):
+            return super()._image_info(
+                image_id, image_hash_key=self.DISK_UEFI1_KEY
+            )
 
         return super()._image_info(
             image_id, image_hash_key=self.DISK1_HASH_KEY

--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -1,8 +1,8 @@
 # This file is part of pycloudlib. See LICENSE file for license information.
 """LXD Cloud type."""
-from contextlib import suppress
 import warnings
 from abc import abstractmethod
+from contextlib import suppress
 
 import yaml
 


### PR DESCRIPTION
Currently if a streams query finds no results, we'll get an
'IndexError: list index out of range' exception at the call site.
This commit adds a more meaningful exception if no images are found from
the streams query.

E.g., from a kinetic run (which hasn't yet hit dailies): https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-kinetic-lxd_container/3/consoleFull

Now we should get a message like:
```
ValueError: No images found matching filters: ['combined_squashfs_sha256=kinetic']
```