### PR TITLE
Create default LXD VM profile

### DIFF
--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -8,7 +8,7 @@ import yaml
 
 from pycloudlib.cloud import BaseCloud
 from pycloudlib.constants import LOCAL_UBUNTU_ARCH
-from pycloudlib.lxd.defaults import LXC_PROFILE_VERSION, base_vm_profiles
+from pycloudlib.lxd.defaults import base_vm_profiles
 from pycloudlib.lxd.instance import LXDInstance, LXDVirtualMachineInstance
 from pycloudlib.util import subp
 

--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -609,9 +609,9 @@ class LXDVirtualMachine(_BaseLXD):
         """
         image_id = self._normalize_image_id(image_id)
         base_release = self._extract_release_from_image_id(image_id)
-        profile_name = "pycloudlib-vm-{}-{}".format(
-            base_release, LXC_PROFILE_VERSION
-        )
+        if base_release not in ["xenial", "bionic"]:
+            base_release = "default"
+        profile_name = f"pycloudlib-vm-{base_release}-{LXC_PROFILE_VERSION}"
 
         self.create_profile(
             profile_name=profile_name,

--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -611,7 +611,7 @@ class LXDVirtualMachine(_BaseLXD):
         base_release = self._extract_release_from_image_id(image_id)
         if base_release not in ["xenial", "bionic"]:
             base_release = "default"
-        profile_name = f"pycloudlib-vm-{base_release}-{LXC_PROFILE_VERSION}"
+        profile_name = f"pycloudlib-vm-{base_release}"
 
         self.create_profile(
             profile_name=profile_name,

--- a/pycloudlib/lxd/defaults.py
+++ b/pycloudlib/lxd/defaults.py
@@ -29,7 +29,7 @@ LXC_SETUP_VENDORDATA = textwrap.dedent(
 VM_PROFILE_TMPL = textwrap.dedent(
     """\
     {vendordata}
-    description: Default LXD profile for {series} VMs
+    description: Pycloudlib LXD profile for {series} VMs
     devices:
       {config_device}
       eth0:
@@ -68,19 +68,7 @@ base_vm_profiles = {
     "bionic": _make_vm_profile(
         "bionic", install_agent=True, config_cloudinit=True
     ),
-    "focal": _make_vm_profile(
-        "focal", install_agent=False, config_cloudinit=False
-    ),
-    "groovy": _make_vm_profile(
-        "groovy", install_agent=False, config_cloudinit=False
-    ),
-    "hirsute": _make_vm_profile(
-        "hirsute", install_agent=False, config_cloudinit=False
-    ),
-    "impish": _make_vm_profile(
-        "impish", install_agent=False, config_cloudinit=False
-    ),
-    "jammy": _make_vm_profile(
-        "jammy", install_agent=False, config_cloudinit=False
+    "default": _make_vm_profile(
+        "default", install_agent=False, config_cloudinit=False
     ),
 }

--- a/pycloudlib/lxd/tests/test_defaults.py
+++ b/pycloudlib/lxd/tests/test_defaults.py
@@ -15,29 +15,10 @@ class TestLXDProfilesWereNotModified:
     # the existing dict we have here. The rationale for that is to avoid
     # us forgetting to bump the profile version when modifying it.
     version_to_md5sum = {
-        "v1": {
-            "xenial": "350af6388522c8c28d8e00152fac98cc",
-            "bionic": "b79ba7ea46882d35e6d10b08c7531f6f",
-            "focal": "9ce4202e39d98c1499e3bce3c144e14f",
-            "groovy": "05b1582d39237fb2d1b55c8782982bfd",
-            "hirsute": "1f3851328bec6253f51b1f1dc9bcbf55",
-        },
-        "v2": {
-            "xenial": "c4f83c97c2f39a39f1e997aa33e4bb66",
-            "bionic": "0e35f88aa29c66374fbd9fe3b4a36257",
-            "focal": "9ce4202e39d98c1499e3bce3c144e14f",
-            "groovy": "05b1582d39237fb2d1b55c8782982bfd",
-            "hirsute": "1f3851328bec6253f51b1f1dc9bcbf55",
-            "impish": "c2a4e4d6a9c16f73f2f79fe34d3f638f",
-        },
         "v3": {
-            "xenial": "da94488cc93ebbb136c1f6830e6b9fcc",
-            "bionic": "0e35f88aa29c66374fbd9fe3b4a36257",
-            "focal": "9ce4202e39d98c1499e3bce3c144e14f",
-            "groovy": "05b1582d39237fb2d1b55c8782982bfd",
-            "hirsute": "1f3851328bec6253f51b1f1dc9bcbf55",
-            "impish": "c2a4e4d6a9c16f73f2f79fe34d3f638f",
-            "jammy": "7329f45a0a46be7a0e9f0acdb7e5908d",
+            "xenial": "1f4d35dc74a550eb6458222a531a24c4",
+            "bionic": "f0e13a4b8d11bc7b3d82c0f06ef72211",
+            "default": "a740b8296455ba0b51ad093c77b0261b",
         },
     }
 

--- a/pycloudlib/lxd/tests/test_defaults.py
+++ b/pycloudlib/lxd/tests/test_defaults.py
@@ -15,6 +15,21 @@ class TestLXDProfilesWereNotModified:
     # the existing dict we have here. The rationale for that is to avoid
     # us forgetting to bump the profile version when modifying it.
     version_to_md5sum = {
+        "v1": {
+            "xenial": "350af6388522c8c28d8e00152fac98cc",
+            "bionic": "b79ba7ea46882d35e6d10b08c7531f6f",
+            "focal": "9ce4202e39d98c1499e3bce3c144e14f",
+            "groovy": "05b1582d39237fb2d1b55c8782982bfd",
+            "hirsute": "1f3851328bec6253f51b1f1dc9bcbf55",
+        },
+        "v2": {
+            "xenial": "c4f83c97c2f39a39f1e997aa33e4bb66",
+            "bionic": "0e35f88aa29c66374fbd9fe3b4a36257",
+            "focal": "9ce4202e39d98c1499e3bce3c144e14f",
+            "groovy": "05b1582d39237fb2d1b55c8782982bfd",
+            "hirsute": "1f3851328bec6253f51b1f1dc9bcbf55",
+            "impish": "c2a4e4d6a9c16f73f2f79fe34d3f638f",
+        },
         "v3": {
             "xenial": "1f4d35dc74a550eb6458222a531a24c4",
             "bionic": "f0e13a4b8d11bc7b3d82c0f06ef72211",


### PR DESCRIPTION
For every new Ubuntu series, we have been creating a new LXD VM profile.
Since the profiles for the past few releases have been the same, we
should be able to a default profile from now on with exceptions for
Xenial and Bionic.