### PR TITLE
Add Kinetic to Azure dailies

### DIFF
--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -18,6 +18,7 @@ UBUNTU_DAILY_IMAGES = {
     "focal": "Canonical:0001-com-ubuntu-server-focal-daily:20_04-daily-lts",
     "impish": "Canonical:0001-com-ubuntu-server-impish-daily:21_10-daily",
     "jammy": "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts",
+    "kinetic": "Canonical:0001-com-ubuntu-server-kinetic-daily:22_10-daily",
 }
 
 UBUNTU_RELEASE_IMAGES = {


### PR DESCRIPTION
Sample log from test on using cloud-init:
```
2022-05-13 13:33:41 INFO      integration_testing:clouds.py:159 Launching instance with launch_kwargs:
image_id=Canonical:0001-com-ubuntu-server-kinetic-daily:22_10-daily
user_data=None
2022-05-13 13:35:16 INFO      pycloudlib.instance:instance.py:183 executing: sh -c whoami
2022-05-13 13:35:16 INFO      paramiko.transport:transport.py:1881 Connected (version 2.0, client OpenSSH_9.0p1)
2022-05-13 13:35:16 INFO      paramiko.transport:transport.py:1881 Authentication (publickey) successful!
2022-05-13 13:35:17 INFO      pycloudlib.instance:instance.py:183 executing: which systemctl
2022-05-13 13:35:17 INFO      pycloudlib.instance:instance.py:183 executing: systemctl is-active cloud-init.target
2022-05-13 13:35:17 INFO      pycloudlib.instance:instance.py:183 executing: cloud-init status --wait --long
Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fb7837aadd8>
2022-05-13 13:35:17 INFO      integration_testing:clouds.py:164 Launched instance: <pycloudlib.azure.instance.AzureInstance object at 0x7fb7837aadd8>
2022-05-13 13:35:17 INFO      pycloudlib.instance:instance.py:183 executing: sudo -- sh -c 'cloud-init --version'
cloud-init version: /usr/bin/cloud-init 22.1-14-g2e17a0d6-0ubuntu1~22.04.5
2022-05-13 13:35:17 INFO      integration_testing:clouds.py:170 cloud-init version: /usr/bin/cloud-init 22.1-14-g2e17a0d6-0ubuntu1~22.04.5
2022-05-13 13:35:17 INFO      pycloudlib.instance:instance.py:183 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
image serial: 20220511
2022-05-13 13:35:18 INFO      integration_testing:clouds.py:174 image serial: 20220511
---------------------------------------------------------------------------------------- live log call ----------------------------------------------------------------------------------------
2022-05-13 13:35:18 INFO      pycloudlib.instance:instance.py:183 executing: sudo -- sh -c 'cat /etc/lsb-release'
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=22.10
DISTRIB_CODENAME=kinetic
DISTRIB_DESCRIPTION="Ubuntu Kinetic Kudu (development branch)"
```