### PR TITLE
pin google-api-python-client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ def read_readme():
 INSTALL_REQUIRES = [
     "boto3 >= 1.14.20",
     "botocore >= 1.17.20",
-    "google-api-python-client >= 1.7.7",
+    "google-api-python-client >= 1.7.7, < 2.49.0",
+    "protobuf < 3.12.0",
     "paramiko >= 2.9.2",
     "pyyaml >= 5.1",
     "requests >= 2.22",


### PR DESCRIPTION
Set max version of google-api-python-client to < v2.49.0
Set max version of protobuff to < 3.12.0

google-api-python-client v2.49.0 was released yesterday, and it looks like this updated a protobuf dependency to require Python 3.7. 

Error log in cloud-init:
```
Collecting protobuf>=3.12.0

  Downloading https://files.pythonhosted.org/packages/6c/be/4e32d02bf08b8f76bf6e59f2a531690c1e4264530404501f3489ca975d9a/protobuf-4.21.0-py2.py3-none-any.whl (164kB)

ERROR: Package 'protobuf' requires a different Python: 3.6.10 not in '>=3.7'

=================================== log end ====================================

ERROR: could not install deps [-r/home/travis/build/canonical/cloud-init/integration-requirements.txt]; v = InvocationError('/home/travis/build/canonical/cloud-init/.tox/integration-tests-ci/bin/python -m pip install -r/home/travis/build/canonical/cloud-init/integration-requirements.txt', 1)
```