### PR TITLE
util: update UBUNTU_RELEASE_VERSION_MAP for oci

### DIFF
--- a/pycloudlib/util.py
+++ b/pycloudlib/util.py
@@ -15,6 +15,8 @@ from errno import ENOENT
 from pycloudlib.result import Result
 
 UBUNTU_RELEASE_VERSION_MAP = {
+    "kinetic": "22.10",
+    "jammy": "22.04",
     "focal": "20.04",
     "bionic": "18.04",
     "xenial": "16.04",


### PR DESCRIPTION
OCI relies on UBUNTU_RELEASE_VERSION_MAP for image stream lookup.
Add relevant known Ubuntu release maps to aid in image discovery.