### PR TITLE
oci: select proper subnet matching availability_domain

### DIFF
--- a/pycloudlib/oci/cloud.py
+++ b/pycloudlib/oci/cloud.py
@@ -221,6 +221,9 @@ class OCI(BaseCloud):
         for subnet in subnets:
             if subnet.availability_domain == self.availability_domain:
                 subnet_id = subnet.id
+                break
+        else:
+            subnet_id = subnets[0].id
         if not subnet_id:
             raise Exception(
                 f"Unabled to determine subnet id for domain: "

--- a/pycloudlib/oci/cloud.py
+++ b/pycloudlib/oci/cloud.py
@@ -214,11 +214,18 @@ class OCI(BaseCloud):
 
         """
         vcn_id = self.network_client.list_vcns(self.compartment_id).data[0].id
-        subnet = self.network_client.list_subnets(
+        subnets = self.network_client.list_subnets(
             self.compartment_id, vcn_id=vcn_id
-        ).data[0]
-        subnet_id = subnet.id
-
+        ).data
+        subnet_id = None
+        for subnet in subnets:
+            if subnet.availability_domain == self.availability_domain:
+                subnet_id = subnet.id
+        if not subnet_id:
+            raise Exception(
+                f"Unabled to determine subnet id for domain: "
+                f"{self.availability_domain}"
+            )
         metadata = {
             "ssh_authorized_keys": self.key_pair.public_key_content,
         }


### PR DESCRIPTION
There can be multiple subnets in a virtual cloud network (VCN).
Typically we see 3 subnets in an availability_domain like ua-ashburn-1:
 - US-ASHBURN-AD-1
 - US-ASHBURN-AD-2
 - US-ASHBURN-AD-3

pycloudlib must select the appropriate subnet matching the specific
availability_domain and not just source the first subnet at index 0.

Wrong subnet ID results in 400 erros from python SDK or UI dashboard
errors such as:
A problem occurred while preparing the instance's VNIC.
    ((400, InvalidParameter, false)
Parameter 'availabilityDomain' does not match.
VNIC has 'iad-ad-3' while the subnet has 'iad-ad-1'
    (opc-request-id: dummyRequestId))