### PR TITLE
dependencies: relax versioned dependencies (SC-1090)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ def read_readme():
 INSTALL_REQUIRES = [
     "boto3 >= 1.14.20",
     "botocore >= 1.17.20",
-    "google-api-python-client >= 1.7.7, < 2.49.0",
-    "protobuf < 3.12.0",
+    "google-api-python-client >= 1.7.7",
+    "protobuf < 3.20.0",
     "paramiko >= 2.9.2",
     "pyyaml >= 5.1",
     "requests >= 2.22",


### PR DESCRIPTION
protobuf dropped support for Python 3.6 in version 3.20, so we can allow
anything older than that.
    
As of today google-api-python-client's README.md [2] says that "Python
3.6, 3.7, 3.8, 3.9 and 3.10 are fully supported and tested", so we
should be safe without an upper bound.
    
[1] https://github.com/protocolbuffers/protobuf/commit/301d315dc4674
[2] https://github.com/googleapis/google-api-python-client/blob/b698f9c/README.md