### PR TITLE
OciInstance: Implement network interface methods

### DIFF
--- a/examples/oci.py
+++ b/examples/oci.py
@@ -21,7 +21,7 @@ def demo(availability_domain, compartment_id):
     through a number of examples.
     """
     client = pycloudlib.OCI(
-        "Oracle test",
+        "oracle-test",
         availability_domain=availability_domain,
         compartment_id=compartment_id,
     )


### PR DESCRIPTION
OciInstance: Implement network interface methods

- Implement `add_network_interface` and `remove_network_interface`.
- Fix example