### PR TITLE
aws: add support for pro fips machine

### DIFF
--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -126,7 +126,7 @@ class EC2(BaseCloud):
             )
 
         if image_type == ImageType.PRO_FIPS:
-            return "ubuntu-pro-fips/images/hvm-ssd/ubuntu-{}-{}-*".format(
+            return "ubuntu-pro-fips*/images/hvm-ssd/ubuntu-{}-{}-*".format(
                 release, UBUNTU_RELEASE_VERSION_MAP[release]
             )
 


### PR DESCRIPTION
On AWS, the location of the Pro FIPS machine starts with `ubuntu-pro-fips-server`. We are updating our name filter to address that.