### PR TITLE
gce: always fetch latest image

### DIFF
--- a/pycloudlib/cloud.py
+++ b/pycloudlib/cloud.py
@@ -41,7 +41,9 @@ class BaseCloud(ABC):
             timestamp_suffix: Append a timestamped suffix to the tag string.
             config_file: path to pycloudlib configuration file
         """
-        self._log = logging.getLogger(__name__)
+        self._log = logging.getLogger(
+            "{}.{}".format(__name__, self.__class__.__name__)
+        )
         self.config = parse_config(config_file)[self._type]
 
         user = getpass.getuser()


### PR DESCRIPTION
Test the before and after with 
```python
import logging

import pycloudlib
from pycloudlib.cloud import ImageType

logging.basicConfig(level=logging.DEBUG)

gce = pycloudlib.GCE(tag="test")
for r in ["xenial", "bionic", "focal", "jammy", "kinetic"]:
    gce.daily_image(r, image_type=ImageType.GENERIC)
for r in ["xenial", "bionic", "focal", "jammy"]:
    gce.daily_image(r, image_type=ImageType.PRO)
for r in ["bionic", "focal"]:
    gce.daily_image(r, image_type=ImageType.PRO_FIPS)
```

You may need to add a logging statement to see the image name/creation date returned before this commit.

Before this commit, the fetched gce xenial image was out of date (from 2018).
This also changes all gce LTS images to be the latest **daily** image as implied by the method name `daily_image`.