### PR TITLE
Dynamic config support

### DIFF
--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -82,7 +82,18 @@ class Azure(BaseCloud):
             tenant_id: user's tenant id key
             region: The region where the instance will be created
         """
-        super().__init__(tag, timestamp_suffix, config_file)
+        super().__init__(
+            tag,
+            timestamp_suffix,
+            config_file,
+            required_values=[
+                client_id,
+                client_secret,
+                subscription_id,
+                tenant_id,
+            ],
+        )
+
         self._log.debug("logging into Azure")
         self.location = region or self.config.get("region") or "centralus"
         self.username = "ubuntu"

--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -41,7 +41,12 @@ class EC2(BaseCloud):
             secret_access_key: user's secret access key
             region: region to login to
         """
-        super().__init__(tag, timestamp_suffix, config_file)
+        super().__init__(
+            tag,
+            timestamp_suffix,
+            config_file,
+            required_values=[access_key_id, secret_access_key, region],
+        )
         self._log.debug("logging into EC2")
 
         try:

--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -53,7 +53,13 @@ class GCE(BaseCloud):
             service_account_email: service account to bind launched
                                    instances to
         """
-        super().__init__(tag, timestamp_suffix, config_file)
+        super().__init__(
+            tag,
+            timestamp_suffix,
+            config_file,
+            required_values=[credentials_path, project],
+        )
+
         self._log.debug("logging into GCE")
 
         self.credentials_path = ""

--- a/pycloudlib/openstack/cloud.py
+++ b/pycloudlib/openstack/cloud.py
@@ -34,7 +34,10 @@ class Openstack(BaseCloud):
             network: Name of the network to use (from openstack network list)
 
         """  # noqa: E501
-        super().__init__(tag, timestamp_suffix, config_file)
+        super().__init__(
+            tag, timestamp_suffix, config_file, required_values=[network]
+        )
+
         self.network = network or self.config["network"]
         self._openstack_keypair = None
         self.conn = openstack.connect()


### PR DESCRIPTION
Removes the requirement for pycloudlib and OCI config files to be in a
fixed path so pycloudlib can operate as a library. This allows specifying
parameters for the clouds independently of the config files, facilitating
integration with automated pipelines.