### PR TITLE
lxd: support multiple interfaces for lxd bridges

### DIFF
--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -70,6 +70,10 @@ class LXDInstance(BaseInstance):
         return subp(base_cmd + list(command), rcs=None)
 
     def parse_ip(self, query: dict):
+        """Return ip address from lxd query.
+
+        Returns None if no address found
+        """
         network = query.get("state", {}).get("network", {})
         for _, nic_cfg in network.items():
             if not nic_cfg.get("host_name"):

--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -119,7 +119,7 @@ class LXDInstance(BaseInstance):
                     info = json.loads(result.stdout)
                 except ValueError:
                     self._log.debug(
-                        "Unable to parse output of cmd: %s. Expected YAML,"
+                        "Unable to parse output of cmd: %s. Expected JSON,"
                         " got: %s. Retrying %d time(s)...",
                         command,
                         result.stdout,

--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -85,6 +85,7 @@ class LXDInstance(BaseInstance):
             "Unable to find valid IP. Found network: %s",
             network,
         )
+        return None
 
     @property
     def is_vm(self):

--- a/pycloudlib/lxd/tests/test_instance.py
+++ b/pycloudlib/lxd/tests/test_instance.py
@@ -259,12 +259,16 @@ class TestIP:
                 stdout=stdouts[0], stderr=stderr, return_code=return_code
             )
         instance = LXDInstance(name="my_vm")
-
+        lxc_mock = mock.call(
+            ["lxc", "query", "/1.0/instances/my_vm?recursion=1"]
+        )
         if isinstance(expected, Exception):
             with pytest.raises(type(expected), match=re.escape(str(expected))):
                 instance.ip  # pylint: disable=pointless-statement
+            assert [lxc_mock] * sleeps == m_subp.call_args_list
         else:
             assert expected == instance.ip
+            assert [lxc_mock] * (1 + sleeps) == m_subp.call_args_list
         assert sleeps == m_sleep.call_count
 
     def test_parse_ip(self):

--- a/pycloudlib/lxd/tests/test_instance.py
+++ b/pycloudlib/lxd/tests/test_instance.py
@@ -2,6 +2,7 @@
 import re
 from unittest import mock
 from json import dumps
+from copy import deepcopy
 
 import pytest
 
@@ -274,8 +275,9 @@ class TestIP:
     def test_parse_ip(self):
         """Verify ipv4 parser"""
         assert "10.161.80.57" == LXDInstance(name="my_vm").parse_ip(LXD_QUERY)
-        LXD_QUERY.get("state", {}).get("network", {}).pop("enp5s0")
-        assert LXDInstance(name="my_vm").parse_ip(LXD_QUERY) is None
+        local = deepcopy(LXD_QUERY)
+        local.get("state", {}).get("network", {}).pop("enp5s0")
+        assert LXDInstance(name="my_vm").parse_ip(local) is None
 
 
 class TestWaitForStop:

--- a/pycloudlib/lxd/tests/test_instance.py
+++ b/pycloudlib/lxd/tests/test_instance.py
@@ -1,8 +1,8 @@
 """Tests for pycloudlib.lxd.instance."""
 import re
-from unittest import mock
-from json import dumps
 from copy import deepcopy
+from json import dumps
+from unittest import mock
 
 import pytest
 
@@ -18,20 +18,20 @@ LXD_QUERY = {
                         "address": "10.161.80.57",
                         "family": "inet",
                         "netmask": "24",
-                        "scope": "global"
+                        "scope": "global",
                     },
                     {
                         "address": "fd42:80e2:4695:1e96:216:3eff:fe06:e5f6",
                         "family": "inet6",
                         "netmask": "64",
-                        "scope": "global"
+                        "scope": "global",
                     },
                     {
                         "address": "fe80::216:3eff:fe06:e5f6",
                         "family": "inet6",
                         "netmask": "64",
-                        "scope": "link"
-                    }
+                        "scope": "link",
+                    },
                 ],
                 "counters": {
                     "bytes_received": 627023316,
@@ -41,13 +41,13 @@ LXD_QUERY = {
                     "packets_dropped_inbound": 0,
                     "packets_dropped_outbound": 0,
                     "packets_received": 344183,
-                    "packets_sent": 71759
+                    "packets_sent": 71759,
                 },
                 "host_name": "tap55cb7af1",
                 "hwaddr": "00:16:3e:06:e5:f6",
                 "mtu": 1500,
                 "state": "up",
-                "type": "broadcast"
+                "type": "broadcast",
             },
             "lo": {
                 "addresses": [
@@ -55,14 +55,14 @@ LXD_QUERY = {
                         "address": "127.0.0.1",
                         "family": "inet",
                         "netmask": "8",
-                        "scope": "local"
+                        "scope": "local",
                     },
                     {
                         "address": "::1",
                         "family": "inet6",
                         "netmask": "128",
-                        "scope": "local"
-                    }
+                        "scope": "local",
+                    },
                 ],
                 "counters": {
                     "bytes_received": 67612,
@@ -72,13 +72,13 @@ LXD_QUERY = {
                     "packets_dropped_inbound": 0,
                     "packets_dropped_outbound": 0,
                     "packets_received": 654,
-                    "packets_sent": 654
+                    "packets_sent": 654,
                 },
                 "host_name": "",
                 "hwaddr": "",
                 "mtu": 65536,
                 "state": "up",
-                "type": "loopback"
+                "type": "loopback",
             },
             "veth1998ea41": {
                 "addresses": [],
@@ -90,19 +90,19 @@ LXD_QUERY = {
                     "packets_dropped_inbound": 0,
                     "packets_dropped_outbound": 0,
                     "packets_received": 1210,
-                    "packets_sent": 42
+                    "packets_sent": 42,
                 },
                 "host_name": "",
                 "hwaddr": "56:f1:b2:7f:8b:32",
                 "mtu": 1500,
                 "state": "up",
-                "type": "broadcast"
-            }
+                "type": "broadcast",
+            },
         },
         "pid": 182418,
         "processes": 46,
         "status": "Running",
-        "status_code": 103
+        "status_code": 103,
     },
 }
 
@@ -248,6 +248,7 @@ class TestIP:
         self, m_subp, m_sleep, stdouts, stderr, return_code, sleeps, expected
     ):
         """IPv4 output matches specific vm name from `lxc list`.
+
         Errors are retried and result in TimeoutError on failure.
         """
         if len(stdouts) > 1:
@@ -273,7 +274,7 @@ class TestIP:
         assert sleeps == m_sleep.call_count
 
     def test_parse_ip(self):
-        """Verify ipv4 parser"""
+        """Verify ipv4 parser."""
         assert "10.161.80.57" == LXDInstance(name="my_vm").parse_ip(LXD_QUERY)
         local = deepcopy(LXD_QUERY)
         local.get("state", {}).get("network", {}).pop("enp5s0")

--- a/pycloudlib/lxd/tests/test_instance.py
+++ b/pycloudlib/lxd/tests/test_instance.py
@@ -1,11 +1,109 @@
 """Tests for pycloudlib.lxd.instance."""
 import re
 from unittest import mock
+from json import dumps
 
 import pytest
 
 from pycloudlib.lxd.instance import LXDInstance, LXDVirtualMachineInstance
 from pycloudlib.result import Result
+
+LXD_QUERY = {
+    "state": {
+        "network": {
+            "enp5s0": {
+                "addresses": [
+                    {
+                        "address": "10.161.80.57",
+                        "family": "inet",
+                        "netmask": "24",
+                        "scope": "global"
+                    },
+                    {
+                        "address": "fd42:80e2:4695:1e96:216:3eff:fe06:e5f6",
+                        "family": "inet6",
+                        "netmask": "64",
+                        "scope": "global"
+                    },
+                    {
+                        "address": "fe80::216:3eff:fe06:e5f6",
+                        "family": "inet6",
+                        "netmask": "64",
+                        "scope": "link"
+                    }
+                ],
+                "counters": {
+                    "bytes_received": 627023316,
+                    "bytes_sent": 5159667,
+                    "errors_received": 0,
+                    "errors_sent": 0,
+                    "packets_dropped_inbound": 0,
+                    "packets_dropped_outbound": 0,
+                    "packets_received": 344183,
+                    "packets_sent": 71759
+                },
+                "host_name": "tap55cb7af1",
+                "hwaddr": "00:16:3e:06:e5:f6",
+                "mtu": 1500,
+                "state": "up",
+                "type": "broadcast"
+            },
+            "lo": {
+                "addresses": [
+                    {
+                        "address": "127.0.0.1",
+                        "family": "inet",
+                        "netmask": "8",
+                        "scope": "local"
+                    },
+                    {
+                        "address": "::1",
+                        "family": "inet6",
+                        "netmask": "128",
+                        "scope": "local"
+                    }
+                ],
+                "counters": {
+                    "bytes_received": 67612,
+                    "bytes_sent": 67612,
+                    "errors_received": 0,
+                    "errors_sent": 0,
+                    "packets_dropped_inbound": 0,
+                    "packets_dropped_outbound": 0,
+                    "packets_received": 654,
+                    "packets_sent": 654
+                },
+                "host_name": "",
+                "hwaddr": "",
+                "mtu": 65536,
+                "state": "up",
+                "type": "loopback"
+            },
+            "veth1998ea41": {
+                "addresses": [],
+                "counters": {
+                    "bytes_received": 100604,
+                    "bytes_sent": 13587,
+                    "errors_received": 0,
+                    "errors_sent": 0,
+                    "packets_dropped_inbound": 0,
+                    "packets_dropped_outbound": 0,
+                    "packets_received": 1210,
+                    "packets_sent": 42
+                },
+                "host_name": "",
+                "hwaddr": "56:f1:b2:7f:8b:32",
+                "mtu": 1500,
+                "state": "up",
+                "type": "broadcast"
+            }
+        },
+        "pid": 182418,
+        "processes": 46,
+        "status": "Running",
+        "status_code": 103
+    },
+}
 
 
 class TestRestart:
@@ -114,13 +212,13 @@ class TestIP:
                 ),
             ),
             (  # retry on non-zero exit code
-                ["10.0.0.1 (eth0)"],
+                [dumps(LXD_QUERY)],
                 "",
                 1,
                 150,
                 TimeoutError(
                     "Unable to determine IP address after 150 retries."
-                    " exit:1 stdout: 10.0.0.1 (eth0) stderr: "
+                    " exit:1 stdout:"
                 ),
             ),
             (  # empty values will retry indefinitely
@@ -134,13 +232,13 @@ class TestIP:
                 ),
             ),
             (  # only retry until success
-                ["unparseable", "10.69.10.5 (eth0)\n"],
+                ["unparseable", dumps(LXD_QUERY)],
                 "",
                 0,
                 1,
-                "10.69.10.5",
+                "10.161.80.57",
             ),
-            (["10.69.10.5 (eth0)\n"], "", 0, 0, "10.69.10.5"),
+            ([dumps(LXD_QUERY)], "", 0, 0, "10.161.80.57"),
         ),
     )
     @mock.patch("pycloudlib.lxd.instance.time.sleep")
@@ -149,7 +247,6 @@ class TestIP:
         self, m_subp, m_sleep, stdouts, stderr, return_code, sleeps, expected
     ):
         """IPv4 output matches specific vm name from `lxc list`.
-
         Errors are retried and result in TimeoutError on failure.
         """
         if len(stdouts) > 1:
@@ -162,17 +259,19 @@ class TestIP:
                 stdout=stdouts[0], stderr=stderr, return_code=return_code
             )
         instance = LXDInstance(name="my_vm")
-        lxc_mock = mock.call(
-            ["lxc", "list", "^my_vm$", "-c4", "--format", "csv"]
-        )
+
         if isinstance(expected, Exception):
             with pytest.raises(type(expected), match=re.escape(str(expected))):
                 instance.ip  # pylint: disable=pointless-statement
-            assert [lxc_mock] * sleeps == m_subp.call_args_list
         else:
             assert expected == instance.ip
-            assert [lxc_mock] * (1 + sleeps) == m_subp.call_args_list
         assert sleeps == m_sleep.call_count
+
+    def test_parse_ip(self):
+        """Verify ipv4 parser"""
+        assert "10.161.80.57" == LXDInstance(name="my_vm").parse_ip(LXD_QUERY)
+        LXD_QUERY.get("state", {}).get("network", {}).pop("enp5s0")
+        assert LXDInstance(name="my_vm").parse_ip(LXD_QUERY) is None
 
 
 class TestWaitForStop:


### PR DESCRIPTION
This (straw man) approach selects the non-lxd bridge between two interfaces. It solves the problem where the second interface is created via nested instances. I'm fine if we'd rather reject this solution in favor of something less quick and dirty.