### PR TITLE
feat(oracle): add kwargs for oci operations

### DIFF
--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -475,7 +475,7 @@ class Azure(BaseCloud):
 
         return vm_poller.result()
 
-    def delete_image(self, image_id):
+    def delete_image(self, image_id, **kwargs):
         """Delete an image from Azure.
 
         Args:

--- a/pycloudlib/cloud.py
+++ b/pycloudlib/cloud.py
@@ -70,11 +70,12 @@ class BaseCloud(ABC):
             self.tag = validate_tag(tag)
 
     @abstractmethod
-    def delete_image(self, image_id):
+    def delete_image(self, image_id, **kwargs):
         """Delete an image.
 
         Args:
             image_id: string, id of the image to delete
+            **kwargs: dictionary of other arguments to pass to delete_image
         """
         raise NotImplementedError
 

--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -248,7 +248,7 @@ class EC2(BaseCloud):
         )
         return self._find_image_serial(image_id, image_type)
 
-    def delete_image(self, image_id):
+    def delete_image(self, image_id, **kwargs):
         """Delete an image.
 
         Args:

--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -284,7 +284,7 @@ class GCE(BaseCloud):
         """
         raise NotImplementedError
 
-    def delete_image(self, image_id):
+    def delete_image(self, image_id, **kwargs):
         """Delete an image.
 
         Args:

--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -475,7 +475,7 @@ class _BaseLXD(BaseCloud):
 
         return image_info[0]["version_name"]
 
-    def delete_image(self, image_id):
+    def delete_image(self, image_id, **kwargs):
         """Delete the image.
 
         Args:

--- a/pycloudlib/openstack/cloud.py
+++ b/pycloudlib/openstack/cloud.py
@@ -42,7 +42,7 @@ class Openstack(BaseCloud):
         self._openstack_keypair = None
         self.conn = openstack.connect()
 
-    def delete_image(self, image_id):
+    def delete_image(self, image_id, **kwargs):
         """Delete an image.
 
         Args:


### PR DESCRIPTION
Adds kwargs support for all oci operations.

Example usage: Oracle's SDK has retry strategies that can be used for most operations. Even though some of them (like launch_instance) do not retry by default, a retry strategy can be specified.