### PR TITLE
Remove smoke call requiring older API

### DIFF
--- a/pycloudlib/azure/util.py
+++ b/pycloudlib/azure/util.py
@@ -36,8 +36,6 @@ def get_client(resource, config_dict: dict):
         credential = AzureCliCredential()
         subscription_id = config_dict.get("subscriptionId")
         client = resource(credential, subscription_id=subscription_id)
-        # smoke test: This raises ClientAuthenticationError when CLI absent
-        _ = next(client.operations.list())
         return client
     except CLIError:
         logger.debug(


### PR DESCRIPTION
The call removed here functionally does nothing, yet will result in:
```
azure.core.exceptions.ResourceNotFoundError: (InvalidResourceType) The resource type 'operations' could not be found in the namespace 'Microsoft.Resources' for api version '2021-04-01'. The supported api-versions are '2015-01-01'.
Code: InvalidResourceType
Message: The resource type 'operations' could not be found in the namespace 'Microsoft.Resources' for api version '2021-04-01'. The supported api-versions are '2015-01-01'.
```

Let's remove it until we can come up with a better check.