### PR TITLE
azure: if az command absent, use explicit config params

### DIFF
--- a/pycloudlib/instance.py
+++ b/pycloudlib/instance.py
@@ -486,7 +486,7 @@ class BaseInstance(ABC):
     def _wait_for_cloudinit(self):
         """Wait until cloud-init has finished."""
         self._log.info("_wait_for_cloudinit to complete")
-        if self.execute(["which", "systemctl"]).ok:
+        if self.execute("command -v systemctl").ok:
             # We may have issues with cloud-init status early boot, so also
             # ensure our cloud-init.target is active as an extra layer of
             # protection against connecting before the system is ready

--- a/pycloudlib/tests/test_instance.py
+++ b/pycloudlib/tests/test_instance.py
@@ -234,7 +234,7 @@ class TestWaitForCloudinit:
         ) as m_execute:
             instance._wait_for_cloudinit()
         expected = [
-            mock.call(["which", "systemctl"]),
+            mock.call("command -v systemctl"),
             *(
                 [
                     mock.call(


### PR DESCRIPTION
## please rebase merge when approved. I'd like a separate commit for which -> command -v in instance.py

When no 'az' command is installed, avoid relying on a default client created by:
client = resource(credential, subscription_id=subscription_id)

On systems without az command line client, the default client will later fail with messages like to following:

azure.identity._exceptions.CredentialUnavailableError:
   Azure CLI not found