### PR TITLE
mypy: add type checking

### DIFF
--- a/examples/base_api.py
+++ b/examples/base_api.py
@@ -68,7 +68,7 @@ def exercise_api(client: BaseCloud, image_id=None):
     instance.delete()
 
 
-ALL_CLOUDS = {
+ALL_CLOUDS: dict = {
     pycloudlib.Azure: {},
     pycloudlib.EC2: {},
     pycloudlib.GCE: {

--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -57,15 +57,15 @@ class Azure(BaseCloud):
 
     def __init__(
         self,
-        tag,
-        timestamp_suffix=True,
+        tag: str,
+        timestamp_suffix: bool = True,
         config_file: Optional[ConfigFile] = None,
         *,
-        client_id=None,
-        client_secret=None,
-        subscription_id=None,
-        tenant_id=None,
-        region=None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        subscription_id: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        region: Optional[str] = None,
     ):
         """Initialize the connection to Azure.
 
@@ -535,7 +535,11 @@ class Azure(BaseCloud):
         raise ValueError("Invalid image_type")
 
     def daily_image(
-        self, release, *, image_type: ImageType = ImageType.GENERIC, **kwargs
+        self,
+        release: str,
+        *,
+        image_type: ImageType = ImageType.GENERIC,
+        **kwargs,
     ):
         """Find the image info for the latest daily image for a given release.
 

--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -2,6 +2,7 @@
 """Azure Cloud type."""
 import base64
 import logging
+from typing import Dict, Optional
 
 from azure.mgmt.compute import ComputeManagementClient
 from azure.mgmt.network import NetworkManagementClient
@@ -58,7 +59,7 @@ class Azure(BaseCloud):
         self,
         tag,
         timestamp_suffix=True,
-        config_file: ConfigFile = None,
+        config_file: Optional[ConfigFile] = None,
         *,
         client_id=None,
         client_secret=None,
@@ -99,8 +100,8 @@ class Azure(BaseCloud):
         self.location = region or self.config.get("region") or "centralus"
         self.username = "ubuntu"
 
-        self.registered_instances = {}
-        self.registered_images = {}
+        self.registered_instances: Dict[str, AzureInstance] = {}
+        self.registered_images: Dict[str, dict] = {}
 
         config_dict = {}
 
@@ -533,7 +534,9 @@ class Azure(BaseCloud):
 
         raise ValueError("Invalid image_type")
 
-    def daily_image(self, release, image_type: ImageType = ImageType.GENERIC):
+    def daily_image(
+        self, release, *, image_type: ImageType = ImageType.GENERIC, **kwargs
+    ):
         """Find the image info for the latest daily image for a given release.
 
         Args:

--- a/pycloudlib/azure/util.py
+++ b/pycloudlib/azure/util.py
@@ -40,9 +40,9 @@ def get_client(resource, config_dict: dict):
         )
     else:
         try:
-            credential = AzureCliCredential()
+            cli_credential = AzureCliCredential()
             subscription_id = config_dict.get("subscriptionId")
-            client = resource(credential, subscription_id=subscription_id)
+            client = resource(cli_credential, subscription_id=subscription_id)
             return client
         except CLIError:
             logger.debug(

--- a/pycloudlib/cloud.py
+++ b/pycloudlib/cloud.py
@@ -7,6 +7,7 @@ import io
 import logging
 import os
 from abc import ABC, abstractmethod
+from typing import Optional
 
 import paramiko
 
@@ -35,7 +36,7 @@ class BaseCloud(ABC):
         self,
         tag,
         timestamp_suffix=True,
-        config_file: ConfigFile = None,
+        config_file: Optional[ConfigFile] = None,
         required_values=None,
     ):
         """Initialize base cloud class.

--- a/pycloudlib/cloud.py
+++ b/pycloudlib/cloud.py
@@ -7,7 +7,7 @@ import io
 import logging
 import os
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Optional, Sequence
 
 import paramiko
 
@@ -16,6 +16,8 @@ from pycloudlib.instance import BaseInstance
 from pycloudlib.key import KeyPair
 from pycloudlib.streams import Streams
 from pycloudlib.util import get_timestamped_tag, validate_tag
+
+_RequiredValues = Optional[Sequence[Optional[Any]]]
 
 
 @enum.unique
@@ -34,10 +36,10 @@ class BaseCloud(ABC):
 
     def __init__(
         self,
-        tag,
-        timestamp_suffix=True,
+        tag: str,
+        timestamp_suffix: bool = True,
         config_file: Optional[ConfigFile] = None,
-        required_values=None,
+        required_values: _RequiredValues = None,
     ):
         """Initialize base cloud class.
 
@@ -49,7 +51,7 @@ class BaseCloud(ABC):
         self._log = logging.getLogger(
             "{}.{}".format(__name__, self.__class__.__name__)
         )
-        self.check_and_set_config(config_file, required_values)
+        self._check_and_set_config(config_file, required_values)
 
         user = getpass.getuser()
         self.key_pair = KeyPair(
@@ -95,7 +97,7 @@ class BaseCloud(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def daily_image(self, release, **kwargs):
+    def daily_image(self, release: str, **kwargs):
         """ID of the latest daily image for a particular release.
 
         Args:
@@ -235,7 +237,11 @@ class BaseCloud(ABC):
 
         return result
 
-    def check_and_set_config(self, config_file, required_values):
+    def _check_and_set_config(
+        self,
+        config_file: Optional[ConfigFile],
+        required_values: _RequiredValues,
+    ):
         """Set pycloudlib configuration.
 
         Checks if values required to launch a cloud instance are present.

--- a/pycloudlib/config.py
+++ b/pycloudlib/config.py
@@ -3,7 +3,7 @@ import logging
 import os
 from io import StringIO
 from pathlib import Path
-from typing import Any, MutableMapping, Union
+from typing import Any, MutableMapping, Optional, Union
 
 import toml
 
@@ -31,7 +31,9 @@ class Config(dict):
             ) from None
 
 
-def parse_config(config_file: ConfigFile = None) -> MutableMapping[str, Any]:
+def parse_config(
+    config_file: Optional[ConfigFile] = None,
+) -> MutableMapping[str, Any]:
     """Find the relevant TOML, load, and return it."""
     possible_configs = []
     if config_file:

--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -1,6 +1,7 @@
 # This file is part of pycloudlib. See LICENSE file for license information.
 """AWS EC2 Cloud type."""
 import re
+from typing import Optional
 
 import botocore
 
@@ -21,7 +22,7 @@ class EC2(BaseCloud):
         self,
         tag,
         timestamp_suffix=True,
-        config_file: ConfigFile = None,
+        config_file: Optional[ConfigFile] = None,
         *,
         access_key_id=None,
         secret_access_key=None,
@@ -90,7 +91,12 @@ class EC2(BaseCloud):
         return VPC.create(self.resource, name=name, ipv4_cidr=ipv4_cidr)
 
     def released_image(
-        self, release, arch="x86_64", image_type: ImageType = ImageType.GENERIC
+        self,
+        release,
+        *,
+        arch="x86_64",
+        image_type: ImageType = ImageType.GENERIC,
+        **kwargs,
     ):
         """Find the id of the latest released image for a particular release.
 
@@ -183,7 +189,12 @@ class EC2(BaseCloud):
         return sorted(images["Images"], key=lambda x: x["CreationDate"])[-1]
 
     def daily_image(
-        self, release, arch="x86_64", image_type: ImageType = ImageType.GENERIC
+        self,
+        release,
+        *,
+        arch="x86_64",
+        image_type: ImageType = ImageType.GENERIC,
+        **kwargs,
     ):
         """Find the id of the latest daily image for a particular release.
 

--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -20,13 +20,13 @@ class EC2(BaseCloud):
 
     def __init__(
         self,
-        tag,
-        timestamp_suffix=True,
+        tag: str,
+        timestamp_suffix: bool = True,
         config_file: Optional[ConfigFile] = None,
         *,
-        access_key_id=None,
-        secret_access_key=None,
-        region=None,
+        access_key_id: Optional[str] = None,
+        secret_access_key: Optional[str] = None,
+        region: Optional[str] = None,
     ):
         """Initialize the connection to EC2.
 
@@ -92,9 +92,9 @@ class EC2(BaseCloud):
 
     def released_image(
         self,
-        release,
+        release: str,
         *,
-        arch="x86_64",
+        arch: str = "x86_64",
         image_type: ImageType = ImageType.GENERIC,
         **kwargs,
     ):
@@ -190,9 +190,9 @@ class EC2(BaseCloud):
 
     def daily_image(
         self,
-        release,
+        release: str,
         *,
-        arch="x86_64",
+        arch: str = "x86_64",
         image_type: ImageType = ImageType.GENERIC,
         **kwargs,
     ):

--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -30,15 +30,15 @@ class GCE(BaseCloud):
 
     def __init__(
         self,
-        tag,
-        timestamp_suffix=True,
+        tag: str,
+        timestamp_suffix: bool = True,
         config_file: Optional[ConfigFile] = None,
         *,
-        credentials_path=None,
-        project=None,
-        region=None,
-        zone=None,
-        service_account_email=None,
+        credentials_path: Optional[str] = None,
+        project: Optional[str] = None,
+        region: Optional[str] = None,
+        zone: Optional[str] = None,
+        service_account_email: Optional[str] = None,
     ):
         """Initialize the connection to GCE.
 
@@ -230,9 +230,9 @@ class GCE(BaseCloud):
 
     def daily_image(
         self,
-        release,
+        release: str,
         *,
-        arch="x86_64",
+        arch: str = "x86_64",
         image_type: ImageType = ImageType.GENERIC,
         **kwargs,
     ):

--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -10,6 +10,7 @@ import logging
 import os
 import time
 from itertools import count
+from typing import Optional
 
 import googleapiclient.discovery
 
@@ -31,7 +32,7 @@ class GCE(BaseCloud):
         self,
         tag,
         timestamp_suffix=True,
-        config_file: ConfigFile = None,
+        config_file: Optional[ConfigFile] = None,
         *,
         credentials_path=None,
         project=None,
@@ -117,7 +118,7 @@ class GCE(BaseCloud):
         )
 
     def released_image(
-        self, release, image_type: ImageType = ImageType.GENERIC
+        self, release, *, image_type: ImageType = ImageType.GENERIC, **kwargs
     ):
         """ID of the latest released image for a particular release.
 
@@ -228,7 +229,12 @@ class GCE(BaseCloud):
         return image_list
 
     def daily_image(
-        self, release, arch="x86_64", image_type: ImageType = ImageType.GENERIC
+        self,
+        release,
+        *,
+        arch="x86_64",
+        image_type: ImageType = ImageType.GENERIC,
+        **kwargs,
     ):
         """Find the id of the latest image for a particular release.
 

--- a/pycloudlib/ibm/cloud.py
+++ b/pycloudlib/ibm/cloud.py
@@ -352,10 +352,12 @@ class IBM(BaseCloud):
            A list of strings of key pair names accessible to the cloud.
 
         """
-        return _iter_resources(
-            self._client.list_keys,
-            resource_name="keys",
-            map_fn=lambda key: key["name"],
+        return list(
+            _iter_resources(
+                self._client.list_keys,
+                resource_name="keys",
+                map_fn=lambda key: key["name"],
+            )
         )
 
     def delete_key(self, name: str):

--- a/pycloudlib/ibm/cloud.py
+++ b/pycloudlib/ibm/cloud.py
@@ -28,8 +28,8 @@ class IBM(BaseCloud):
 
     def __init__(
         self,
-        tag,
-        timestamp_suffix=True,
+        tag: str,
+        timestamp_suffix: bool = True,
         config_file: Optional[ConfigFile] = None,
         *,
         resource_group: Optional[str] = None,
@@ -168,7 +168,7 @@ class IBM(BaseCloud):
             raise ValueError(f"Image not found: {os_name}")
         return image["id"]
 
-    def daily_image(self, release, **kwargs) -> str:
+    def daily_image(self, release: str, **kwargs) -> str:
         """ID of the latest daily image for a particular release.
 
         Args:

--- a/pycloudlib/ibm/instance.py
+++ b/pycloudlib/ibm/instance.py
@@ -6,7 +6,7 @@ import logging
 from enum import Enum, auto
 from functools import partial
 from itertools import chain
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 from ibm_cloud_sdk_core import ApiException, DetailedResponse
 from ibm_vpc import VpcV1
@@ -19,11 +19,16 @@ from pycloudlib.ibm._util import iter_resources as _iter_resources
 from pycloudlib.ibm._util import wait_until as _wait_until
 from pycloudlib.instance import BaseInstance
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+    _Action: TypeAlias = _InstanceAction.TypeEnum
+    _Status: TypeAlias = _Instance.StatusEnum
+else:
+    _Action = _InstanceAction.TypeEnum
+    _Status = _Instance.StatusEnum
+
 logger = logging.getLogger(__name__)
-
-_Status = _Instance.StatusEnum
-_Action = _InstanceAction.TypeEnum
-
 VpcV1Fn = Callable[..., DetailedResponse]
 
 
@@ -340,7 +345,9 @@ class _IBMInstanceType(Enum):
         instance_type = instance["profile"]["name"]
         return cls.from_instance_type(instance_type)
 
-    def create_instance(self, client: VpcV1, *args, **kwargs) -> VpcV1Fn:
+    def create_instance(
+        self, client: VpcV1, *args, **kwargs
+    ) -> DetailedResponse:
         """Create instance."""
         if self == self.VSI:
             return client.create_instance(*args, **kwargs)
@@ -402,7 +409,7 @@ class _IBMInstanceType(Enum):
 
     def list_instance_network_interface_floating_ips(
         self, client: VpcV1, *args, **kwargs
-    ) -> VpcV1Fn:
+    ) -> DetailedResponse:
         """List Floating IPs associated to a nic."""
         if self == self.VSI:
             return client.list_instance_network_interface_floating_ips(

--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -374,7 +374,9 @@ class _BaseLXD(BaseCloud):
             arch=arch,
         )
 
-    def daily_image(self, release, arch=LOCAL_UBUNTU_ARCH):
+    def daily_image(
+        self, release: str, arch: str = LOCAL_UBUNTU_ARCH, **kwargs
+    ):
         """Find the LXD fingerprint of the latest daily image.
 
         Args:

--- a/pycloudlib/oci/cloud.py
+++ b/pycloudlib/oci/cloud.py
@@ -24,14 +24,14 @@ class OCI(BaseCloud):
 
     def __init__(
         self,
-        tag,
-        timestamp_suffix=True,
+        tag: str,
+        timestamp_suffix: bool = True,
         config_file: Optional[ConfigFile] = None,
         *,
-        availability_domain=None,
-        compartment_id=None,
-        config_path=None,
-        config_dict=None,
+        availability_domain: Optional[str] = None,
+        compartment_id: Optional[str] = None,
+        config_path: Optional[str] = None,
+        config_dict: Optional[str] = None,
     ):
         """
         Initialize the connection to OCI.
@@ -133,7 +133,10 @@ class OCI(BaseCloud):
         return self.daily_image(release, operating_system)
 
     def daily_image(
-        self, release, operating_system="Canonical Ubuntu", **kwargs
+        self,
+        release: str,
+        operating_system: str = "Canonical Ubuntu",
+        **kwargs,
     ):
         """Get the daily image.
 

--- a/pycloudlib/oci/cloud.py
+++ b/pycloudlib/oci/cloud.py
@@ -6,6 +6,7 @@ import base64
 import json
 import os
 import re
+from typing import Optional
 
 import oci
 
@@ -25,7 +26,7 @@ class OCI(BaseCloud):
         self,
         tag,
         timestamp_suffix=True,
-        config_file: ConfigFile = None,
+        config_file: Optional[ConfigFile] = None,
         *,
         availability_domain=None,
         compartment_id=None,
@@ -83,9 +84,9 @@ class OCI(BaseCloud):
 
         if config_dict:
             try:
-                oci.config.validate_config(config_dict)
+                oci.config.validate_config(config_dict)  # type: ignore
                 self.oci_config = config_dict
-            except oci.exceptions.InvalidConfig as e:
+            except oci.exceptions.InvalidConfig as e:  # type: ignore
                 raise ValueError(
                     "Config dict is invalid. Pass a valid config dict. "
                     "{}".format(e)
@@ -102,11 +103,11 @@ class OCI(BaseCloud):
                     "{} is not a valid config file. Pass a valid config "
                     "file.".format(config_path)
                 )
-            self.oci_config = oci.config.from_file(config_path)
+            self.oci_config = oci.config.from_file(config_path)  # type: ignore
 
         self._log.debug("Logging into OCI")
-        self.compute_client = oci.core.ComputeClient(self.oci_config)
-        self.network_client = oci.core.VirtualNetworkClient(self.oci_config)
+        self.compute_client = oci.core.ComputeClient(self.oci_config)  # type: ignore # noqa: E501
+        self.network_client = oci.core.VirtualNetworkClient(self.oci_config)  # type: ignore # noqa: E501
 
     def delete_image(self, image_id, **kwargs):
         """Delete an image.
@@ -213,6 +214,7 @@ class OCI(BaseCloud):
             key_pair=self.key_pair,
             instance_id=instance_id,
             compartment_id=self.compartment_id,
+            availability_domain=self.availability_domain,
             oci_config=self.oci_config,
         )
 

--- a/pycloudlib/oci/utils.py
+++ b/pycloudlib/oci/utils.py
@@ -32,7 +32,7 @@ def wait_till_ready(func, current_data, desired_state, sleep_seconds=1000):
 
 
 def get_subnet_id(
-    network_client: "oci.core.VirtualNetworkClient",
+    network_client: "oci.core.VirtualNetworkClient",  # type: ignore
     compartment_id: str,
     availability_domain: str,
 ) -> str:

--- a/pycloudlib/openstack/cloud.py
+++ b/pycloudlib/openstack/cloud.py
@@ -1,10 +1,12 @@
 """Openstack cloud type."""
 import base64
+from typing import Optional
 
 import openstack
 
 from pycloudlib.cloud import BaseCloud
 from pycloudlib.config import ConfigFile
+from pycloudlib.key import KeyPair
 from pycloudlib.openstack.instance import OpenstackInstance
 
 
@@ -17,7 +19,7 @@ class Openstack(BaseCloud):
         self,
         tag,
         timestamp_suffix=True,
-        config_file: ConfigFile = None,
+        config_file: Optional[ConfigFile] = None,
         *,
         network=None,
     ):
@@ -39,7 +41,7 @@ class Openstack(BaseCloud):
         )
 
         self.network = network or self.config["network"]
-        self._openstack_keypair = None
+        self._openstack_keypair: Optional[KeyPair] = None
         self.conn = openstack.connect()
 
     def delete_image(self, image_id, **kwargs):
@@ -78,7 +80,7 @@ class Openstack(BaseCloud):
         """
         raise NotImplementedError
 
-    def get_instance(self, instance_id) -> OpenstackInstance:
+    def get_instance(self, instance_id, **kwargs) -> OpenstackInstance:
         """Get an instance by id.
 
         Args:
@@ -195,7 +197,7 @@ class Openstack(BaseCloud):
         super().use_key(public_key_path, private_key_path, name)
         self._openstack_keypair = self._get_openstack_keypair()
 
-    def _get_openstack_keypair(self):
+    def _get_openstack_keypair(self) -> KeyPair:
         """Get openstack keypair corresponding to this instances keypair.
 
         When creating an openstack instance, a keypair (maintained in

--- a/pycloudlib/openstack/cloud.py
+++ b/pycloudlib/openstack/cloud.py
@@ -17,11 +17,11 @@ class Openstack(BaseCloud):
 
     def __init__(
         self,
-        tag,
-        timestamp_suffix=True,
+        tag: str,
+        timestamp_suffix: bool = True,
         config_file: Optional[ConfigFile] = None,
         *,
-        network=None,
+        network: Optional[str] = None,
     ):
         """Initialize the connection to openstack.
 
@@ -60,7 +60,7 @@ class Openstack(BaseCloud):
             "available for any particular openstack setup."
         )
 
-    def daily_image(self, release, **kwargs):
+    def daily_image(self, release: str, **kwargs):
         """Not supported for openstack."""
         raise Exception(
             "Obtaining daily image for a release is not supported on "

--- a/pycloudlib/util.py
+++ b/pycloudlib/util.py
@@ -230,7 +230,7 @@ def touch(path, mode=None):
         chmod(path, mode)
 
 
-def _get_local_ubuntu_arch():
+def _get_local_ubuntu_arch() -> str:
     """Return the Ubuntu architecture suitable for the local system.
 
     This is not simply the local machine hardware name, as in some cases it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,26 @@ target-version = ['py36']
 [tool.isort]
 profile = "black"
 line_length = 79
+
+[tool.mypy]
+follow_imports = "silent"
+warn_unused_ignores = "true"
+warn_redundant_casts = "true"
+exclude=[]
+
+[[tool.mypy.overrides]]
+module = [
+  "azure.*",
+  "boto3",
+  "botocore.*",
+  "google.*",
+  "googleapiclient.*",
+  "ibm_vpc.*",
+  "ibm_cloud_sdk_core.*",
+  "ibm_platform_services.*",
+  "knack.*",
+  "oci.*",
+  "paramiko.*",
+  "simplestreams",
+]
+ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,16 @@
 [tox]
 # As it may be undesired to make formatting changes, by default only check
-envlist = flake8, pylint, pytest, black, isort, docs
+envlist = flake8, pylint, mypy, pytest, black, isort, docs
 skipsdist = true
 
 [common]
 envdir = {toxworkdir}/.testenv
 deps =
+    mypy==0.950
+    types-mock==5.0.0
+    types-pyyaml==6.0.12
+    types-setuptools==65.6.0
+    types-toml==0.10.8
     flake8==4.0.1
     flake8-docstrings==1.6.0
     pylint==2.12.2
@@ -17,6 +22,12 @@ deps =
 envdir = {[common]envdir}
 deps = {[common]deps}
 commands = {envpython} -m pytest --doctest-modules {posargs:--cov pycloudlib -- pycloudlib}
+
+[testenv:mypy]
+envdir = {[common]envdir}
+deps =
+    {[common]deps}
+commands = {envpython} -m mypy pycloudlib examples setup.py
 
 [testenv:pylint]
 envdir = {[common]envdir}


### PR DESCRIPTION
Enable mypy type checking and add more type definitions.

Fix bug in OciInstance.add_network_interface, discovered
by mypy. In a previous refactoring, we factor out the
oci.utils.get_subnet_id function to be used in
oci.cloud and oci.instance. This function does need the
availability_domain but OciInstance had not that attribute.
availability_domain added to OciInstance and fix the bug.