### PR TITLE
lxd: delete ephemeral instances using lxc delete

### DIFF
--- a/pycloudlib/lxd/instance.py
+++ b/pycloudlib/lxd/instance.py
@@ -231,12 +231,7 @@ class LXDInstance(BaseInstance):
         """
         self._log.debug("deleting %s", self.name)
 
-        if self.ephemeral:
-            # We don't need to wait here, since the
-            # instance will be deleted once it is stopped
-            self.shutdown(wait=False)
-        else:
-            subp(["lxc", "delete", self.name, "--force"])
+        subp(["lxc", "delete", self.name, "--force"])
 
         if wait:
             self.wait_for_delete()

--- a/pycloudlib/lxd/tests/test_instance.py
+++ b/pycloudlib/lxd/tests/test_instance.py
@@ -342,12 +342,8 @@ class TestDelete:
         with mock.patch.object(type(instance), "ephemeral", is_ephemeral):
             instance.delete(wait=False)
 
-        if is_ephemeral:
-            assert 1 == m_shutdown.call_count
-            assert 0 == m_subp.call_count
-        else:
-            assert 0 == m_shutdown.call_count
-            assert 1 == m_subp.call_count
-            assert [
-                mock.call(["lxc", "delete", "test", "--force"])
-            ] == m_subp.call_args_list
+        assert 0 == m_shutdown.call_count
+        assert 1 == m_subp.call_count
+        assert [
+            mock.call(["lxc", "delete", "test", "--force"])
+        ] == m_subp.call_args_list


### PR DESCRIPTION
There are cases where ephemeral instances are not running and not
automatically deleted, e.g. when they are in ERROR state. Let's
just call `lxc delete` as we do for non-ephemeral images, and trust
lxd to do the right thing.

This is a partial revert of 0869d07b7894d985e183be957ae8318aae667c00.
