### PR TITLE
[bugfix] Don't raise Exception

### DIFF
--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -174,7 +174,7 @@ class EC2(BaseCloud):
         )
 
         if not images.get("Images"):
-            raise Exception(
+            raise ValueError(
                 "Could not find {} image for {} release".format(
                     image_type.value, release
                 )


### PR DESCRIPTION
In https://github.com/canonical/pycloudlib/commit/efcdf6712bbbdf526a98545b091f897d484e63a0, `daily_image()` was changed to raise an `Exception` when an image is not found. Before that commit this code path was raising a `ValueError` later in `_streams_query()`.

This change broke cloud-init integration test functionality which allowed booting [arbitrary AMIs](https://github.com/canonical/cloud-init/blob/dcd8413c8874b615fc7e3c54da15f6ed5d8dedc7/tests/integration_tests/clouds.py#L132). Switch the raised exception back to `ValueError`.