### PR TITLE
CI: add dependabot.yml to auto-update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/dev"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,0 +1,9 @@
+mypy==0.950
+types-mock==5.0.0
+types-pyyaml==6.0.12
+types-setuptools==65.6.0
+types-toml==0.10.8
+flake8==4.0.1
+flake8-docstrings==1.6.0
+pylint==2.12.2
+black==22.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -6,15 +6,7 @@ skipsdist = true
 [common]
 envdir = {toxworkdir}/.testenv
 deps =
-    mypy==0.950
-    types-mock==5.0.0
-    types-pyyaml==6.0.12
-    types-setuptools==65.6.0
-    types-toml==0.10.8
-    flake8==4.0.1
-    flake8-docstrings==1.6.0
-    pylint==2.12.2
-    black==22.3.0
+    -rdev/requirements.txt
     -rrequirements.txt
     -rtest-requirements.txt
 


### PR DESCRIPTION
GH actions and lint requirements will be try to be updated in autogenerated PRs.