### PR TITLE
dependabot: fix minimum python version

### DIFF
--- a/dev/.python-version
+++ b/dev/.python-version
@@ -1,0 +1,2 @@
+python-3.6
+# Specifies the python version that dependabot should use


### PR DESCRIPTION
Desired commit message:

```
dependabot: fix minimum python version #245 
```

Being the dependabot pip configuration pointing to `dev/`, it is not able to know the minimum required python version. See: https://github.com/canonical/pycloudlib/pull/244

Info on the topic: https://github.com/dependabot/dependabot-core/issues/1455

This burden could be simplified if we move to a pep-0517 compliant build system, as dependabot plays much nicer with `setup.cfg` configs. (We will have to do that at some point as the `setup.py` format is deprecated)