### PR TITLE
ci: fix min py version for dependabot

### DIFF
--- a/dev/.python-version
+++ b/dev/.python-version
@@ -1,2 +1,5 @@
-python-3.6
+3.6.5
 # Specifies the python version that dependabot should use
+# Note: The version must specify major.minor.patch components
+# and be supported on:
+# https://github.com/dependabot/dependabot-core/blob/7822f07e76cab9be6eca86a91aafc8d72bc42536/python/lib/dependabot/python/python_versions.rb


### PR DESCRIPTION
Add fully qualified python version for dependabot