### PR TITLE
error: add new PycloudlibQuotaError to propagate quota errors

### DIFF
--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -20,6 +20,7 @@ from pycloudlib.errors import (
     InstanceNotFoundError,
     NetworkNotFoundError,
     PycloudlibError,
+    PycloudlibQuotaError,
     PycloudlibTimeoutError,
 )
 from pycloudlib.util import get_timestamped_tag, update_nested
@@ -657,6 +658,12 @@ class Azure(BaseCloud):
         except HttpResponseError as e:
             err_code = e.error.code
             err_msg = e.error.message
+
+            if err_code == "OperationNotAllowed":
+                raise PycloudlibQuotaError(
+                    f"Virtual machine creation error: {err_code}\n{err_msg}"
+                ) from e
+
             raise PycloudlibError(
                 f"Virtual machine creation error: {err_code}\n{err_msg}"
             ) from e

--- a/pycloudlib/errors.py
+++ b/pycloudlib/errors.py
@@ -137,3 +137,7 @@ class CleanupError(PycloudlibException):
 
 class MissingPrerequisiteError(PycloudlibException):
     """Raised when a prerequisite is missing."""
+
+
+class PycloudlibQuotaError(PycloudlibException):
+    """Raised when there is not enough quota to create the resource."""


### PR DESCRIPTION
For the user to be able to retry on quota error, we need to be able to propagate this exception.