### PR TITLE
V11 - add networking config types

### DIFF
--- a/examples/az.py
+++ b/examples/az.py
@@ -5,7 +5,7 @@
 import logging
 
 import pycloudlib
-from pycloudlib.cloud import ImageType
+from pycloudlib.types import ImageType
 
 cloud_config = """#cloud-config
 runcmd:

--- a/examples/ec2.py
+++ b/examples/ec2.py
@@ -6,7 +6,7 @@ import logging
 import os
 
 import pycloudlib
-from pycloudlib.cloud import ImageType
+from pycloudlib.types import ImageType
 
 
 def hot_add(ec2, daily):

--- a/examples/gce.py
+++ b/examples/gce.py
@@ -6,7 +6,7 @@ import logging
 import os
 
 import pycloudlib
-from pycloudlib.cloud import ImageType
+from pycloudlib.types import ImageType
 
 
 def manage_ssh_key(gce):

--- a/examples/lxd.py
+++ b/examples/lxd.py
@@ -6,7 +6,7 @@ import logging
 import textwrap
 
 import pycloudlib
-from pycloudlib.cloud import ImageType
+from pycloudlib.types import ImageType
 
 RELEASE = "noble"
 

--- a/pycloudlib/azure/cloud.py
+++ b/pycloudlib/azure/cloud.py
@@ -15,7 +15,7 @@ from azure.mgmt.resource import ResourceManagementClient
 
 from pycloudlib.azure import security_types, util
 from pycloudlib.azure.instance import AzureInstance, VMInstanceStatus
-from pycloudlib.cloud import BaseCloud, ImageType
+from pycloudlib.cloud import BaseCloud
 from pycloudlib.config import ConfigFile
 from pycloudlib.errors import (
     InstanceNotFoundError,
@@ -23,6 +23,7 @@ from pycloudlib.errors import (
     PycloudlibError,
     PycloudlibTimeoutError,
 )
+from pycloudlib.types import ImageType
 from pycloudlib.util import get_timestamped_tag, update_nested
 
 UBUNTU_DAILY_IMAGES = {

--- a/pycloudlib/cloud.py
+++ b/pycloudlib/cloud.py
@@ -1,7 +1,6 @@
 # This file is part of pycloudlib. See LICENSE file for license information.
 """Base class for all other clouds to provide consistent set of functions."""
 
-import enum
 import getpass
 import io
 import logging
@@ -26,16 +25,6 @@ from pycloudlib.util import (
 )
 
 _RequiredValues = Optional[Sequence[Optional[Any]]]
-
-
-@enum.unique
-class ImageType(enum.Enum):
-    """Allowed image types when launching cloud images."""
-
-    GENERIC = "generic"
-    MINIMAL = "minimal"
-    PRO = "Pro"
-    PRO_FIPS = "Pro FIPS"
 
 
 class BaseCloud(ABC):
@@ -179,7 +168,6 @@ class BaseCloud(ABC):
             image_id: string, image ID to use for the instance
             instance_type: string, type of instance to create
             user_data: used by cloud-init to run custom scripts/configuration
-            username: username to use when connecting via SSH
             **kwargs: dictionary of other arguments to pass to launch
 
         Returns:

--- a/pycloudlib/ec2/cloud.py
+++ b/pycloudlib/ec2/cloud.py
@@ -6,12 +6,13 @@ from typing import List, Optional
 
 import botocore
 
-from pycloudlib.cloud import BaseCloud, ImageType
+from pycloudlib.cloud import BaseCloud
 from pycloudlib.config import ConfigFile
 from pycloudlib.ec2.instance import EC2Instance
 from pycloudlib.ec2.util import _get_session, _tag_resource
 from pycloudlib.ec2.vpc import VPC
 from pycloudlib.errors import CloudSetupError, ImageNotFoundError, PycloudlibError
+from pycloudlib.types import ImageType
 from pycloudlib.util import LTS_RELEASES, UBUNTU_RELEASE_VERSION_MAP
 
 # Images before mantic don't have gp3 disk type

--- a/pycloudlib/gce/cloud.py
+++ b/pycloudlib/gce/cloud.py
@@ -16,7 +16,7 @@ from google.api_core.exceptions import GoogleAPICallError
 from google.api_core.extended_operation import ExtendedOperation
 from google.cloud import compute_v1
 
-from pycloudlib.cloud import BaseCloud, ImageType
+from pycloudlib.cloud import BaseCloud
 from pycloudlib.config import ConfigFile
 from pycloudlib.errors import (
     CloudSetupError,
@@ -25,6 +25,7 @@ from pycloudlib.errors import (
 )
 from pycloudlib.gce.instance import GceInstance
 from pycloudlib.gce.util import get_credentials, raise_on_error
+from pycloudlib.types import ImageType
 from pycloudlib.util import UBUNTU_RELEASE_VERSION_MAP, subp
 
 logging.getLogger("google.cloud").setLevel(logging.WARNING)

--- a/pycloudlib/lxd/_images.py
+++ b/pycloudlib/lxd/_images.py
@@ -6,7 +6,7 @@ import json
 import logging
 from typing import Any, List, Optional, Sequence, Tuple
 
-from pycloudlib.cloud import ImageType
+from pycloudlib.types import ImageType
 from pycloudlib.util import subp
 
 _REMOTE_DAILY = "ubuntu-daily"

--- a/pycloudlib/lxd/cloud.py
+++ b/pycloudlib/lxd/cloud.py
@@ -8,11 +8,12 @@ from typing import List, Optional
 
 import yaml
 
-from pycloudlib.cloud import BaseCloud, ImageType
+from pycloudlib.cloud import BaseCloud
 from pycloudlib.constants import LOCAL_UBUNTU_ARCH
 from pycloudlib.lxd import _images
 from pycloudlib.lxd.defaults import base_vm_profiles
 from pycloudlib.lxd.instance import LXDInstance, LXDVirtualMachineInstance
+from pycloudlib.types import ImageType
 from pycloudlib.util import subp
 
 

--- a/pycloudlib/oci/cloud.py
+++ b/pycloudlib/oci/cloud.py
@@ -20,11 +20,13 @@ from pycloudlib.errors import (
 )
 from pycloudlib.oci.instance import OciInstance
 from pycloudlib.oci.utils import (
+    generate_create_vnic_details,
     get_subnet_id,
     get_subnet_id_by_name,
     parse_oci_config_from_env_vars,
     wait_till_ready,
 )
+from pycloudlib.types import NetworkingConfig
 from pycloudlib.util import UBUNTU_RELEASE_VERSION_MAP, subp
 
 
@@ -251,6 +253,7 @@ class OCI(BaseCloud):
             availability_domain=self.availability_domain,
             oci_config=self.oci_config,
             username=username,
+            vcn_name=self.vcn_name,
         )
 
     def launch(
@@ -263,6 +266,7 @@ class OCI(BaseCloud):
         username: Optional[str] = None,
         cluster_id: Optional[str] = None,
         subnet_name: Optional[str] = None,
+        primary_network_config: Optional[NetworkingConfig] = None,
         **kwargs,
     ) -> OciInstance:
         """Launch an instance.
@@ -273,12 +277,14 @@ class OCI(BaseCloud):
                 https://docs.cloud.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm
             user_data: used by Cloud-Init to run custom scripts or
                 provide custom Cloud-Init configuration
-            subnet_name: string, name of subnet to use for instance.
             retry_strategy: a retry strategy from oci.retry module
                 to apply for this operation
             username: username to use when connecting via SSH
             vcn_name: Name of the VCN to use. If not provided, the first VCN
                 found will be used
+            subnet_name: string, name of subnet to use for instance.
+            primary_network_config: NetworkingConfig object to use for configuring the primary
+                network interface
             **kwargs: dictionary of other arguments to pass as
                 LaunchInstanceDetails
 
@@ -297,6 +303,7 @@ class OCI(BaseCloud):
                 self.compartment_id,
                 self.availability_domain,
                 vcn_name=self.vcn_name,
+                networking_config=primary_network_config,
             )
         metadata = {
             "ssh_authorized_keys": self.key_pair.public_key_content,
@@ -314,6 +321,10 @@ class OCI(BaseCloud):
             image_id=image_id,
             metadata=metadata,
             compute_cluster_id=cluster_id,
+            create_vnic_details=generate_create_vnic_details(
+                subnet_id=subnet_id,
+                networking_config=primary_network_config,
+            ),
             **kwargs,
         )
 
@@ -327,6 +338,32 @@ class OCI(BaseCloud):
         )
         self.created_instances.append(instance)
         return instance
+
+    def find_compatible_subnet(self, networking_config: NetworkingConfig) -> str:
+        """
+        Automatically select a subnet that is compatible with the given networking_config.
+
+        In this case, compatible means that the subnet can support the necessary networking type
+        (ipv4 only, ipv6 only, or dual stack) and the private or public requirement.
+        This method will select the first subnet that matches the criteria.
+
+        Args:
+            networking_config: NetworkingConfig object to use for finding a subnet
+
+        Returns:
+            id of the subnet selected
+
+        Raises:
+            `PycloudlibError` if unable to determine `subnet_id` for the given `networking_config`
+        """
+        subnet_id = get_subnet_id(
+            network_client=self.network_client,
+            compartment_id=self.compartment_id,
+            availability_domain=self.availability_domain,
+            vcn_name=self.vcn_name,
+            networking_config=networking_config,
+        )
+        return subnet_id
 
     def snapshot(self, instance, clean=True, name=None):
         """Snapshot an instance and generate an image from it.

--- a/pycloudlib/oci/utils.py
+++ b/pycloudlib/oci/utils.py
@@ -10,6 +10,7 @@ import toml
 from oci.retry import DEFAULT_RETRY_STRATEGY  # pylint: disable=E0611,E0401
 
 from pycloudlib.errors import PycloudlibError, PycloudlibTimeoutError
+from pycloudlib.types import NetworkingConfig, NetworkingType
 
 if TYPE_CHECKING:
     import oci

--- a/pycloudlib/types.py
+++ b/pycloudlib/types.py
@@ -1,0 +1,67 @@
+# This file is part of pycloudlib. See LICENSE file for license information.
+"""This module contains types and enums used by pycloudlib."""
+
+import enum
+from dataclasses import dataclass
+
+
+@enum.unique
+class ImageType(enum.Enum):
+    """Allowed image types when launching cloud images."""
+
+    GENERIC = "generic"
+    MINIMAL = "minimal"
+    PRO = "Pro"
+    PRO_FIPS = "Pro FIPS"
+
+
+@enum.unique
+class NetworkingType(enum.Enum):
+    """Allowed networking configurations for instances."""
+
+    IPV4 = "ipv4"
+    IPV6 = "ipv6"
+    DUAL_STACK = "dual-stack"
+    AUTO = "auto"
+
+    def __str__(self):
+        """Return the string representation of NetworkingType enum."""
+        return self.value
+
+
+@dataclass
+class NetworkingConfig:
+    """
+    Dataclass for specifying or representing networking configuration.
+
+    By default, networking_type is set to AUTO and private is set to False to allow for a publicly
+    accessible instance.
+
+    Descriptions of possible configurations:
+    - If private is set to True, the instance will be accessible only within the cloud network.
+    - If networking_type is set to AUTO, the cloud provider will automatically choose the
+    networking configuration (default/current behavior).
+    - If networking_type is set to IPV4, the instance will only be assigned IPv4 addresses
+    (if private is False, the instance will have a public IPv4 address).
+    - If networking_type is set to IPV6, the instance will only be assigned IPv6 addresses
+    (if private is False, the instance will have a public IPv6 address).
+    - If networking_type is set to DUAL_STACK, the instance will be assigned both IPv4 and IPv6
+    addresses (if private is False, the instance will have both public IPv4 and IPv6 addresses).
+    """
+
+    networking_type: NetworkingType = NetworkingType.AUTO
+    private: bool = False
+
+    def __post_init__(self):
+        """Post initialization checks for NetworkingConfig."""
+        if not isinstance(self.networking_type, NetworkingType):
+            raise ValueError("Invalid networking type provided")
+        if not isinstance(self.private, bool):
+            raise ValueError("Invalid private value provided (must be a boolean)")
+
+    def to_dict(self) -> dict:
+        """Convert the NetworkingConfig to a dictionary representation."""
+        return {
+            "networking_type": self.networking_type.value,
+            "private": self.private,
+        }

--- a/tests/integration_tests/oracle/test_launch.py
+++ b/tests/integration_tests/oracle/test_launch.py
@@ -1,0 +1,161 @@
+"""
+Integration test that exercise functionality specific to Oracle's launch function.
+
+The basic lifecycle stuff is already tested in `tests/integration_tests/test_public_api.py`, but
+these tests go beyond the standard tests that exercise the base cloud agnostic functionality.
+"""
+
+import json
+import logging
+
+import pytest
+
+from pycloudlib.oci.cloud import OCI
+from pycloudlib.types import NetworkingConfig, NetworkingType
+
+logger = logging.getLogger(__name__)
+
+
+# create fixture that provides the oracle cloud object
+@pytest.fixture(scope="module")
+def oracle_cloud():
+    """Provide an OCI cloud instance for tests with automatic cleanup.
+
+    Returns:
+        An OCI cloud instance configured for testing.
+    """
+    # make sure region, AD, and compartment_id are set in your pycloudlib.toml config file
+    # use context manager - instances will be deleted automatically after the test
+    with OCI(
+        tag="oracle-integrations-test-launch",
+    ) as oracle_cloud:
+        yield oracle_cloud
+
+
+class TestOracleLaunch:
+    """
+    Test Oracle Cloud Infrastructure instance launch functionality.
+
+    This class contains tests specific to the OCI launch method,
+    including various network configurations.
+    """
+
+    @pytest.mark.parametrize(
+        ("instance_type",),
+        [
+            pytest.param(
+                "VM.Standard2.1",
+                id="VM",
+            ),
+            pytest.param(
+                "BM.Optimized3.36",
+                id="BM",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        (
+            "primary_private",
+            "primary_networking_type",
+            "secondary_private",
+            "secondary_networking_type",
+        ),
+        [
+            # both public ipv4
+            pytest.param(
+                False,
+                NetworkingType.IPV4,
+                True,
+                NetworkingType.IPV4,
+                id="both_public_ipv4",
+            ),
+            # both public ipv6
+            pytest.param(
+                False,
+                NetworkingType.IPV6,
+                True,
+                NetworkingType.IPV6,
+                id="both_public_ipv6",
+            ),
+            # primary public dual stack, secondary private ipv4
+            pytest.param(
+                False,
+                NetworkingType.DUAL_STACK,
+                True,
+                NetworkingType.DUAL_STACK,
+                id="public_dual_stack_private_dual_stack",
+            ),
+        ],
+    )
+    def test_launch_with_networking_configs(
+        self,
+        oracle_cloud: OCI,
+        primary_private: bool,
+        primary_networking_type: NetworkingType,
+        secondary_private: bool,
+        secondary_networking_type: NetworkingType,
+        instance_type: str,
+    ):
+        """Test OCI instance launch with various networking configurations.
+
+        This test verifies that instances can be launched with different
+        combinations of networking configurations (IPv4, IPv6, dual-stack)
+        for both primary and secondary network interfaces.
+
+        Args:
+            oracle_cloud (OCI): The OCI cloud fixture.
+            primary_private (bool): Whether primary NIC should be private.
+            primary_networking_type (NetworkingType): Network type for primary NIC.
+            secondary_private (bool): Whether secondary NIC should be private.
+            secondary_networking_type (NetworkingType): Network type for secondary NIC.
+            instance_type (str): OCI instance type to launch.
+
+        Test Steps:
+            1. Launch an instance with the specified primary networking configuration and
+                instance type
+            2. Add a secondary network interface with the specified secondary networking
+                configuration
+            3. Restart the instance to apply the changes (As of 20250226 cloud-init does not support
+                hotplugging nics on Oracle)
+            4. Verify that the instance has the expected number of VNICs in IMDS
+        """
+        primary_networking_config = NetworkingConfig(
+            private=primary_private,
+            networking_type=primary_networking_type,
+        )
+
+        logger.info("Launching instance...")
+        instance = oracle_cloud.launch(
+            image_id="ocid1.image.oc1.iad.aaaaaaaasukfowgzghuwrljl4ohlpv3uadhm5sn5dderkhhyymelebrzoima",
+            primary_network_config=primary_networking_config,
+            instance_type=instance_type,
+        )
+        logger.info("Instance launched. Waiting for instance to be ready...")
+        instance.wait()
+        logger.info("Instance is ready!")
+        assert instance.execute("true").ok
+
+        if primary_networking_config.networking_type == NetworkingType.IPV6:
+            imds_vnics_url = "curl http://[fd00:c1::a9fe:a9fe]/opc/v1/vnics"
+        else:
+            imds_vnics_url = "curl http://169.254.169.254/opc/v1/vnics"
+
+        secondary_networking_config = NetworkingConfig(
+            private=secondary_private,
+            networking_type=secondary_networking_type,
+        )
+        instance.add_network_interface(
+            nic_index=(1 if instance_type == "BM.Optimized3.36" else 0),
+            networking_config=secondary_networking_config,
+        )
+
+        # run cloud-init clean and restart instance now that secondary NIC has been added
+        logger.info("Running cloud-init clean and restarting instance...")
+        instance.execute("cloud-init clean", use_sudo=True)
+        instance.restart(wait=True)
+
+        logger.info("Getting VNIC data from IMDS at '%s'...", imds_vnics_url)
+        imds_response_2 = instance.execute(f"curl -s {imds_vnics_url}").stdout
+        vnic_data_2 = json.loads(imds_response_2)
+        logger.info("VNIC data from IMDS after adding secondary NIC: %s", imds_response_2)
+        assert len(vnic_data_2) == 2, "Expected IMDS to return 2 VNICs after adding secondary NIC"

--- a/tests/integration_tests/oracle/test_utils.py
+++ b/tests/integration_tests/oracle/test_utils.py
@@ -1,0 +1,98 @@
+"""Integration tests for Oracle's utility functions."""
+
+import logging
+
+import pytest
+
+from pycloudlib.oci.cloud import OCI
+from pycloudlib.types import NetworkingConfig, NetworkingType
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def oci_cloud():
+    """Fixture to create an OCI cloud instance."""
+    with OCI(
+        tag="oracle-integrations-test-utils",
+        vcn_name="ipv6-vcn",
+        region="us-ashburn-1",
+        compartment_id="ocid1.compartment.oc1..aaaaaaaayyvhlkxdjkhzu56is7qenv35h4jfh26oconxsro4qr2qx6ezgbpq",
+        availability_domain="qIZq:US-ASHBURN-AD-2",
+    ) as oracle_cloud:
+        yield oracle_cloud
+
+
+# These are pre-existing subnets that I have created in my Oracle Cloud account.
+# this is not immediately reproducible by others, but all they need to do is create 3 subnets
+# that match the below configurations and update the following variables with the new subnet ids.
+# This is the only way I could feel confident that my subnet selection logic is working with the
+# new networking configuration options as expected.
+IPV6_PUBLIC_SUBNET_ID = (
+    "ocid1.subnet.oc1.iad.FILL_THIS_IN"
+)
+DUAL_STACK_PUBLIC_SUBNET_ID = (
+    "ocid1.subnet.oc1.iad.FILL_THIS_IN"
+)
+DUAL_STACK_PRIVATE_SUBNET_ID = (
+    "ocid1.subnet.oc1.iad.FILL_THIS_IN"
+)
+
+
+@pytest.mark.parametrize(
+    ["networking_type", "private", "expected_subnet_id"],
+    [
+        pytest.param(
+            NetworkingType.IPV6,
+            False,
+            IPV6_PUBLIC_SUBNET_ID,
+            id="ipv6_public",
+        ),
+        pytest.param(
+            NetworkingType.DUAL_STACK,
+            True,
+            DUAL_STACK_PRIVATE_SUBNET_ID,
+            id="dual_stack_private",
+        ),
+        pytest.param(
+            NetworkingType.DUAL_STACK,
+            False,
+            DUAL_STACK_PUBLIC_SUBNET_ID,
+            id="dual_stack_public",
+        ),
+        pytest.param(
+            NetworkingType.IPV4,
+            False,
+            DUAL_STACK_PUBLIC_SUBNET_ID,
+            id="ipv4_public",
+        ),
+        pytest.param(
+            NetworkingType.IPV4,
+            True,
+            DUAL_STACK_PRIVATE_SUBNET_ID,
+            id="ipv4_private",
+        ),
+    ],
+)
+def test_oci_subnet_finding(oci_cloud: OCI, networking_type, private, expected_subnet_id):
+    """
+    Test finding a subnet in OCI.
+
+    We are validating that the correct subnet is found based on the type of networking and whether
+    the instance should be publicly accessible or not.
+    """
+    network_config: NetworkingConfig = NetworkingConfig(
+        networking_type=networking_type,
+        private=private,
+    )
+    subnet_id = oci_cloud.find_compatible_subnet(
+        networking_config=network_config,
+    )
+
+    logger.info(
+        f"Found subnet ID: {subnet_id} for networking type: {networking_type} "
+        f"and privacy: {private}"
+    )
+    assert subnet_id == expected_subnet_id, (
+        f"Expected subnet ID: {expected_subnet_id} but got: {subnet_id}",
+    )

--- a/tests/integration_tests/test_public_api.py
+++ b/tests/integration_tests/test_public_api.py
@@ -8,7 +8,8 @@ from tempfile import TemporaryDirectory
 import pytest
 
 import pycloudlib
-from pycloudlib.cloud import BaseCloud, ImageType
+from pycloudlib.cloud import BaseCloud
+from pycloudlib.types import ImageType
 from pycloudlib.instance import BaseInstance
 from pycloudlib.util import LTS_RELEASES, UBUNTU_RELEASE_VERSION_MAP
 

--- a/tests/unit_tests/ec2/test_cloud.py
+++ b/tests/unit_tests/ec2/test_cloud.py
@@ -3,7 +3,7 @@
 import mock
 import pytest
 
-from pycloudlib.cloud import ImageType
+from pycloudlib.types import ImageType
 from pycloudlib.ec2.cloud import EC2
 
 # mock module path

--- a/tests/unit_tests/gce/test_cloud.py
+++ b/tests/unit_tests/gce/test_cloud.py
@@ -3,7 +3,7 @@
 import mock
 import pytest
 
-from pycloudlib.cloud import ImageType
+from pycloudlib.types import ImageType
 from pycloudlib.gce.cloud import GCE
 from pycloudlib.result import Result
 

--- a/tests/unit_tests/lxd/test_cloud.py
+++ b/tests/unit_tests/lxd/test_cloud.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from pycloudlib.cloud import ImageType
+from pycloudlib.types import ImageType
 from pycloudlib.lxd.cloud import LXDContainer, LXDVirtualMachine
 
 M_PATH = "pycloudlib.lxd.cloud."

--- a/tests/unit_tests/lxd/test_images.py
+++ b/tests/unit_tests/lxd/test_images.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 
-from pycloudlib.cloud import ImageType
+from pycloudlib.types import ImageType
 from pycloudlib.lxd import _images
 
 M_PATH = "pycloudlib.lxd._images."

--- a/tests/unit_tests/oci/test_instance.py
+++ b/tests/unit_tests/oci/test_instance.py
@@ -197,7 +197,7 @@ class TestOciInstanceVnicOperations:
 
     def test_add_network_interface(self, setup_vnic_mocks):
         """Test add_network_interface() method."""
-        oci_instance = setup_vnic_mocks
+        oci_instance: OciInstance = setup_vnic_mocks
 
         # Call add_network_interface and check result
         result = oci_instance.add_network_interface()

--- a/tests/unit_tests/oci/test_utils.py
+++ b/tests/unit_tests/oci/test_utils.py
@@ -5,7 +5,9 @@ from pycloudlib.oci.utils import (
     get_subnet_id_by_name,
     parse_oci_config_from_env_vars,
     _load_and_preprocess_oci_toml_file,
+    generate_create_vnic_details,
 )
+from pycloudlib.types import NetworkingConfig, NetworkingType
 from pycloudlib.errors import PycloudlibError
 from oci.retry import DEFAULT_RETRY_STRATEGY  # pylint: disable=E0611,E0401
 import os
@@ -34,9 +36,9 @@ class TestGetSubnetId:
         network_client.list_vcns.return_value.data = []
         with pytest.raises(PycloudlibError, match="Unable to determine vcn name"):
             get_subnet_id(
-                network_client,
-                compartment_id,
-                availability_domain,
+                network_client=network_client,
+                compartment_id=compartment_id,
+                availability_domain=availability_domain,
                 vcn_name="vcn_name",
             )
 
@@ -46,9 +48,9 @@ class TestGetSubnetId:
         network_client.list_vcns.return_value.data = [MagicMock(), MagicMock()]
         with pytest.raises(PycloudlibError, match="Found multiple vcns with name"):
             get_subnet_id(
-                network_client,
-                compartment_id,
-                availability_domain,
+                network_client=network_client,
+                compartment_id=compartment_id,
+                availability_domain=availability_domain,
                 vcn_name="vcn_name",
             )
 
@@ -57,7 +59,11 @@ class TestGetSubnetId:
         network_client, compartment_id, availability_domain = setup_environment
         network_client.list_vcns.return_value.data = []
         with pytest.raises(PycloudlibError, match="No VCNs found in compartment"):
-            get_subnet_id(network_client, compartment_id, availability_domain)
+            get_subnet_id(
+                network_client=network_client,
+                compartment_id=compartment_id,
+                availability_domain=availability_domain,
+            )
 
     def test_get_subnet_id_fails_with_no_suitable_subnet_found(self, setup_environment):
         """Test get_subnet_id fails when no suitable subnet is found."""
@@ -68,7 +74,11 @@ class TestGetSubnetId:
         network_client.list_vcns.return_value.data = [vcn]
         network_client.list_subnets.return_value.data = []
         with pytest.raises(PycloudlibError, match="Unable to find suitable subnet in VCN"):
-            get_subnet_id(network_client, compartment_id, availability_domain)
+            get_subnet_id(
+                network_client=network_client,
+                compartment_id=compartment_id,
+                availability_domain=availability_domain,
+            )
 
     def test_get_subnet_id_fails_with_private_subnet(self, setup_environment):
         """Test that passing private=False ignores private subnets."""
@@ -82,10 +92,10 @@ class TestGetSubnetId:
         network_client.list_subnets.return_value.data = [subnet]
         with pytest.raises(PycloudlibError, match="Unable to find suitable subnet"):
             get_subnet_id(
-                network_client,
-                compartment_id,
-                availability_domain,
-                private=False,
+                network_client=network_client,
+                compartment_id=compartment_id,
+                availability_domain=availability_domain,
+                networking_config=NetworkingConfig(private=False),
             )
 
     def test_get_subnet_id_fails_with_different_availability_domain(self, setup_environment):
@@ -100,7 +110,11 @@ class TestGetSubnetId:
         subnet.availability_domain = "different_availability_domain"
         network_client.list_subnets.return_value.data = [subnet]
         with pytest.raises(PycloudlibError, match="Unable to find suitable subnet in VCN"):
-            get_subnet_id(network_client, compartment_id, availability_domain)
+            get_subnet_id(
+                network_client=network_client,
+                compartment_id=compartment_id,
+                availability_domain=availability_domain,
+            )
 
     def test_get_subnet_id_suceeds_without_vcn_name(self, setup_environment):
         """Test get_subnet_id suceeds without specifying a VCN name."""
@@ -117,11 +131,17 @@ class TestGetSubnetId:
         subnet.availability_domain = None
         subnet.id = "subnet_id"
         network_client.list_subnets.return_value.data = [subnet]
-        result = get_subnet_id(network_client, compartment_id, availability_domain)
+        result = get_subnet_id(
+            network_client=network_client,
+            compartment_id=compartment_id,
+            availability_domain=availability_domain,
+        )
         assert result == "subnet_id"
         # Ensure that list_subnets is called with the first VCN's ID, not the second
         network_client.list_subnets.assert_called_with(
-            compartment_id, vcn_id="vcn1_id", retry_strategy=DEFAULT_RETRY_STRATEGY
+            compartment_id=compartment_id,
+            vcn_id="vcn1_id",
+            retry_strategy=DEFAULT_RETRY_STRATEGY,
         )
 
     def test_get_subnet_id_suceeds_with_vcn_name(self, setup_environment):
@@ -137,15 +157,17 @@ class TestGetSubnetId:
         subnet.id = "subnet_id"
         network_client.list_subnets.return_value.data = [subnet]
         result = get_subnet_id(
-            network_client,
-            compartment_id,
-            availability_domain,
+            network_client=network_client,
+            compartment_id=compartment_id,
+            availability_domain=availability_domain,
             vcn_name="vcn_name",
         )
         assert result == "subnet_id"
         # Ensure that list_subnets is called with the specified VCN's ID
         network_client.list_subnets.assert_called_with(
-            compartment_id, vcn_id="vcn_id", retry_strategy=DEFAULT_RETRY_STRATEGY
+            compartment_id=compartment_id,
+            vcn_id="vcn_id",
+            retry_strategy=DEFAULT_RETRY_STRATEGY,
         )
 
     def test_get_subnet_id_succeeds_with_private_subnet(self, setup_environment):
@@ -164,7 +186,12 @@ class TestGetSubnetId:
         public_subnet.availability_domain = None
         public_subnet.id = "public_subnet_id"
         network_client.list_subnets.return_value.data = [public_subnet, private_subnet]
-        result = get_subnet_id(network_client, compartment_id, availability_domain, private=True)
+        result = get_subnet_id(
+            network_client=network_client,
+            compartment_id=compartment_id,
+            availability_domain=availability_domain,
+            networking_config=NetworkingConfig(private=True),
+        )
         assert result == "private_subnet_id"
 
 
@@ -402,3 +429,165 @@ class TestGetSubnetIdByName:
         network_client.list_subnets.return_value.data = [subnet_mock]
         result = get_subnet_id_by_name(network_client, "compartment_id", "single_subnet")
         assert result == "subnet_id"
+
+
+class TestGetSubnetIdParameterized:
+    @pytest.fixture
+    def setup_environment(self):
+        """Set up the test environment."""
+        network_client = MagicMock()
+        compartment_id = "compartment_id"
+        availability_domain = "availability_domain"
+        vcn = MagicMock()
+        vcn.id = "vcn_id"
+        vcn.display_name = "vcn_name"
+        network_client.list_vcns.return_value.data = [vcn]
+        return network_client, compartment_id, availability_domain, vcn
+
+    @pytest.mark.parametrize(
+        "networking_type, private, expected_subnet_id",
+        [
+            (NetworkingType.IPV4, False, "ipv4_public_subnet_id"),
+            (NetworkingType.IPV4, True, "ipv4_private_subnet_id"),
+            (NetworkingType.IPV6, False, "ipv6_public_subnet_id"),
+            (NetworkingType.IPV6, True, "ipv6_private_subnet_id"),
+            (NetworkingType.DUAL_STACK, False, "dual_stack_public_subnet_id"),
+            (NetworkingType.DUAL_STACK, True, "dual_stack_private_subnet_id"),
+        ],
+    )
+    def test_get_subnet_id_parameterized(
+        self,
+        setup_environment,
+        networking_type,
+        private,
+        expected_subnet_id,
+    ):
+        """Test get_subnet_id with different networking types and private flag."""
+        (
+            network_client,
+            compartment_id,
+            availability_domain,
+            vcn,
+        ) = setup_environment
+
+        # Create subnet mocks based on the parameters
+        ipv4_public_subnet = MagicMock()
+        ipv4_public_subnet.availability_domain = None
+        ipv4_public_subnet.prohibit_internet_ingress = False
+        ipv4_public_subnet.cidr_block = "10.0.0.0/24"
+        ipv4_public_subnet.ipv6_cidr_block = None
+        ipv4_public_subnet.id = "ipv4_public_subnet_id"
+
+        ipv4_private_subnet = MagicMock()
+        ipv4_private_subnet.availability_domain = None
+        ipv4_private_subnet.prohibit_internet_ingress = True
+        ipv4_private_subnet.cidr_block = "10.0.1.0/24"
+        ipv4_private_subnet.ipv6_cidr_block = None
+        ipv4_private_subnet.id = "ipv4_private_subnet_id"
+
+        ipv6_public_subnet = MagicMock()
+        ipv6_public_subnet.availability_domain = None
+        ipv6_public_subnet.prohibit_internet_ingress = False
+        ipv6_public_subnet.cidr_block = None
+        ipv6_public_subnet.ipv6_cidr_block = "2603:c020:400d:5d7e::/64"
+        ipv6_public_subnet.id = "ipv6_public_subnet_id"
+
+        ipv6_private_subnet = MagicMock()
+        ipv6_private_subnet.availability_domain = None
+        ipv6_private_subnet.prohibit_internet_ingress = True
+        ipv6_private_subnet.cidr_block = None
+        ipv6_private_subnet.ipv6_cidr_block = "2603:c020:400d:5d7f::/64"
+        ipv6_private_subnet.id = "ipv6_private_subnet_id"
+
+        dual_stack_public_subnet = MagicMock()
+        dual_stack_public_subnet.availability_domain = None
+        dual_stack_public_subnet.prohibit_internet_ingress = False
+        dual_stack_public_subnet.cidr_block = "10.0.2.0/24"
+        dual_stack_public_subnet.ipv6_cidr_block = "2603:c020:400d:5d80::/64"
+        dual_stack_public_subnet.id = "dual_stack_public_subnet_id"
+
+        dual_stack_private_subnet = MagicMock()
+        dual_stack_private_subnet.availability_domain = None
+        dual_stack_private_subnet.prohibit_internet_ingress = True
+        dual_stack_private_subnet.cidr_block = "10.0.3.0/24"
+        dual_stack_private_subnet.ipv6_cidr_block = "2603:c020:400d:5d81::/64"
+        dual_stack_private_subnet.id = "dual_stack_private_subnet_id"
+
+        network_client.list_subnets.return_value.data = [
+            ipv4_public_subnet,
+            ipv4_private_subnet,
+            ipv6_public_subnet,
+            ipv6_private_subnet,
+            dual_stack_public_subnet,
+            dual_stack_private_subnet,
+        ]
+
+        networking_config = NetworkingConfig(
+            networking_type=networking_type,
+            private=private,
+        )
+
+        result = get_subnet_id(
+            network_client=network_client,
+            compartment_id=compartment_id,
+            availability_domain=availability_domain,
+            networking_config=networking_config,
+        )
+
+        assert result == expected_subnet_id
+
+
+class TestGenerateCreateVnicDetails:
+    subnet_id = "subnet_id"
+
+    def test_generate_create_vnic_details_default(self):
+        """Test generate_create_vnic_details with default parameters."""
+
+        vnic_details = generate_create_vnic_details(self.subnet_id)
+        assert vnic_details.subnet_id == self.subnet_id
+        assert vnic_details.assign_ipv6_ip is False
+        assert vnic_details.assign_public_ip is True
+
+    def test_generate_create_vnic_details_ipv4_public(self):
+        """Test generate_create_vnic_details with IPv4 public configuration."""
+        networking_config = NetworkingConfig(networking_type=NetworkingType.IPV4, private=False)
+        vnic_details = generate_create_vnic_details(self.subnet_id, networking_config)
+        assert vnic_details.subnet_id == self.subnet_id
+        assert vnic_details.assign_ipv6_ip is False
+        assert vnic_details.assign_public_ip is True
+
+    def test_generate_create_vnic_details_ipv4_private(self):
+        """Test generate_create_vnic_details with IPv4 private configuration."""
+        networking_config = NetworkingConfig(networking_type=NetworkingType.IPV4, private=True)
+        vnic_details = generate_create_vnic_details(self.subnet_id, networking_config)
+        assert vnic_details.subnet_id == self.subnet_id
+        assert vnic_details.assign_ipv6_ip is False
+        assert vnic_details.assign_public_ip is False
+
+    def test_generate_create_vnic_details_ipv6(self):
+        """Test generate_create_vnic_details with IPv6 configuration."""
+        networking_config = NetworkingConfig(networking_type=NetworkingType.IPV6)
+        vnic_details = generate_create_vnic_details(self.subnet_id, networking_config)
+        assert vnic_details.subnet_id == self.subnet_id
+        assert vnic_details.assign_ipv6_ip is True
+        assert vnic_details.assign_public_ip is False
+
+    def test_generate_create_vnic_details_dual_stack_public(self):
+        """Test generate_create_vnic_details with dual stack public configuration."""
+        networking_config = NetworkingConfig(
+            networking_type=NetworkingType.DUAL_STACK, private=False
+        )
+        vnic_details = generate_create_vnic_details(self.subnet_id, networking_config)
+        assert vnic_details.subnet_id == self.subnet_id
+        assert vnic_details.assign_ipv6_ip is True
+        assert vnic_details.assign_public_ip is True
+
+    def test_generate_create_vnic_details_dual_stack_private(self):
+        """Test generate_create_vnic_details with dual stack private configuration."""
+        networking_config = NetworkingConfig(
+            networking_type=NetworkingType.DUAL_STACK, private=True
+        )
+        vnic_details = generate_create_vnic_details(self.subnet_id, networking_config)
+        assert vnic_details.subnet_id == self.subnet_id
+        assert vnic_details.assign_ipv6_ip is True
+        assert vnic_details.assign_public_ip is False

--- a/tests/unit_tests/test_types.py
+++ b/tests/unit_tests/test_types.py
@@ -1,0 +1,19 @@
+"""Test types module."""
+
+from pycloudlib.types import NetworkingConfig
+import pytest
+import re
+
+
+def test_networking_config_post_init_raises_exceptions():
+    """Test NetworkingConfig post init checks."""
+    with pytest.raises(
+        ValueError,
+        match="Invalid networking type provided",
+    ):
+        NetworkingConfig(networking_type="invalid")
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Invalid private value provided (must be a boolean)"),
+    ):
+        NetworkingConfig(private="not_a_boolean")


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Pycloudlib! 

                              ____
     ________________________/ O  \___/
    <_O_O_O_O_O_O_O_O_O_O_O_O_____/   \

-->

## Description
<!-- 
Describe the changes in this PR, and reference issues that this PR relates to.
If referencing an issue, say "Fixes #1234" to automatically close the issue when the PR is merged.
-->
This PR seeks to add the ability to uniformly identify and specify networking config across clouds, with initial sweeping implementation being made to Oracle cloud. 

The creation of a new `NetworkingType` enum and a `NetworkingConfig` dataclass should hopefully make it easy and standardized to represent networking for an instance or any of its NICs across clouds.

## Additional Context and Relevant Issues
<!-- Add any other context about the PR here. -->
<!-- If not relevant, leave "N/A" -->

## Test Steps
<!-- Please provide steps to test the changes in this PR, if applicable -->
<!-- If not relevant, leave "N/A" -->
- Ran the new integration tests I wrote:
  - `tox -e integration-tests -- tests/integration_tests/oracle/test_launch.py`
  - `tox -e integration-tests -- tests/integration_tests/oracle/test_utils.py`
- Ran the full `test_public_api` CI locally (`tox -e integration-tests-ci`)
- Added significant unit test coverage over modified oracle functions relating to networking configs
- Ran coverage locally and compared with my changed code and verified any new call sites have either direct unit or integration test coverage