### PR TITLE
feat!: add ability to retain snapshot after cleanup

### DIFF
--- a/pycloudlib/ibm_classic/cloud.py
+++ b/pycloudlib/ibm_classic/cloud.py
@@ -81,6 +81,7 @@ class IBMClassic(BaseCloud):
             ) from e
         except SoftLayer.SoftLayerAPIError as e:
             raise IBMClassicException(f"Error deleting image {image_id}") from e
+        self._record_image_deletion(image_id)
 
     def released_image(self, release, *, disk_size: str = "25G", **kwargs):
         """ID (globalIdentifier) of the latest released image for a particular release.
@@ -267,7 +268,9 @@ class IBMClassic(BaseCloud):
     def snapshot(
         self,
         instance,
+        *,
         clean=True,
+        keep=False,
         note: Optional[str] = None,
         **kwargs,
     ):
@@ -276,6 +279,7 @@ class IBMClassic(BaseCloud):
         Args:
             instance: Instance to snapshot
             clean: run instance clean method before taking snapshot
+            keep: keep the snapshot after the cloud instance is cleaned up
             note: optional note to add to the snapshot
 
         Returns:
@@ -290,10 +294,10 @@ class IBMClassic(BaseCloud):
             name=f"{self.tag}-snapshot",
             notes=note,
         )
-        self._log.info(
-            "Successfully created snapshot '%s' with ID: %s",
-            snapshot_result["name"],
-            snapshot_result["id"],
+        self._store_snapshot_info(
+            snapshot_name=snapshot_result["name"],
+            snapshot_id=snapshot_result["id"],
+            keep_snapshot=keep,
         )
         return snapshot_result["id"]
 

--- a/pycloudlib/types.py
+++ b/pycloudlib/types.py
@@ -65,3 +65,33 @@ class NetworkingConfig:
             "networking_type": self.networking_type.value,
             "private": self.private,
         }
+
+
+@dataclass
+class ImageInfo:
+    """Dataclass that represents an image on any given cloud."""
+
+    image_id: str
+    image_name: str
+
+    def __str__(self):
+        """Return a human readable string representation of the image."""
+        return f"{self.image_name} [id: {self.image_id}]"
+
+    def __repr__(self):
+        """Return a string representation of the image."""
+        return f"ImageInfo(id={self.image_id}, name={self.image_name})"
+
+    def __eq__(self, other):
+        """
+        Check if two ImageInfo objects represent the same image.
+
+        Only the id is used for comparison since this should be the unique identifier for an image.
+        """
+        if not isinstance(other, ImageInfo):
+            return False
+        return self.image_id == other.image_id
+
+    def __dict__(self):
+        """Return a dictionary representation of the image."""
+        return {"image_id": self.image_id, "image_name": self.image_name}

--- a/pycloudlib/vmware/cloud.py
+++ b/pycloudlib/vmware/cloud.py
@@ -100,6 +100,8 @@ class VMWare(BaseCloud):
         except subprocess.CalledProcessError as e:
             if "not found" not in str(e):
                 raise
+        else:
+            self._record_image_deletion(image_id)
 
     def daily_image(self, release: str, **kwargs):
         """Return released_image for VMWare.
@@ -220,12 +222,13 @@ class VMWare(BaseCloud):
         instance.start()
         return instance
 
-    def snapshot(self, instance, clean=True, **kwargs):
+    def snapshot(self, instance, *, clean=True, keep=False, **kwargs):
         """Snapshot an instance and generate an image from it.
 
         Args:
             instance: Instance to snapshot
             clean: run instance clean method before taking snapshot
+            keep: keep the snapshot after the cloud instance is cleaned up
 
         Returns:
             An image id
@@ -246,6 +249,10 @@ class VMWare(BaseCloud):
             check=True,
         )
 
-        self.created_images.append(image_name)
+        self._store_snapshot_info(
+            snapshot_name=image_name,
+            snapshot_id=image_name,
+            keep_snapshot=keep,
+        )
 
         return image_name


### PR DESCRIPTION
<!--
Thank you for submitting a PR to Pycloudlib! 

                              ____
     ________________________/ O  \___/
    <_O_O_O_O_O_O_O_O_O_O_O_O_____/   \

-->
<!--
## PR Checklist

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull
request.

- [ ] I have added unit tests to cover the new behavior under ``tests/unit_tests/```
- [ ] I have run `tox -e format` locally to automatically format my code before submitting
- [ ] I have run `tox` locally ensuring that it passes before submitting
- [ ] (if applicable) I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] My commits are atomic and follow the convetional commit message format (https://www.conventionalcommits.org/en/v1.0.0/)

Otherwise, please leave the PR as a draft to indicate that it is still a work in progress.
-->

## Description
<!-- 
Describe the changes in this PR, and reference issues that this PR relates to.
If referencing an issue, say "Fixes #1234" to automatically close the issue when the PR is merged.
-->
```
feat!: add ability to retain snapshot after cleanup

This allows for marking snapshots to be kept at time of creation instead of being cleaned up automatically. This allows for still using context managers for easy cleanup while retaining snapshots where desired. This functionality can also be used when not using context managers and instead the cloud.clean() method is manually called, like in cloud-init's integration tests.

BREAKING CHANGE: signature of cloud.snapshot() public method has been changed and now all args except for the first (instance) must be passed as named args.
```
## Additional Context and Relevant Issues
<!-- Add any other context about the PR here. -->
<!-- If not relevant, leave "N/A" -->

## Test Steps
<!-- Please provide steps to test the changes in this PR, if applicable -->
<!-- If not relevant, leave "N/A" -->
