### PR TITLE
fix(azure): mypy linting error

### DIFF
--- a/pycloudlib/azure/instance.py
+++ b/pycloudlib/azure/instance.py
@@ -301,6 +301,7 @@ class AzureInstance(BaseInstance):
         vm_nics_ids = [nic.id for nic in self._instance["vm"].network_profile.network_interfaces]
         all_nics: List[NetworkInterface] = list(self._network_client.network_interfaces.list_all())
         vm_nics = [nic for nic in all_nics if nic.id in vm_nics_ids]
+        primary_nic: Optional[NetworkInterface] = None
         primary_nic = [nic for nic in vm_nics if nic.primary][0]
         nic_params = []
         nic_to_remove: Optional[NetworkInterface] = None


### PR DESCRIPTION
## Description
Fix mypy liniting error.

## Additional Context and Relevant Issues

linting error:
```
mypy: commands[0]> .tox/.testenv/bin/python -m mypy pycloudlib examples setup.py
pycloudlib/azure/instance.py:317: error: Incompatible types in assignment (expression has type "None", variable has type "NetworkInterface")
Found 1 error in 1 file (checked 64 source files)
```

## Test Steps

`tox -e mypy`
Automatically handled by CI on this PR

