### PR TITLE
fix: unpin upper constraint for pyparsing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     openstacksdk >= 1.1.0, < 1.5.0
     paramiko >= 2.9.2
     protobuf
-    pyparsing >= 2, < 3.0.0
+    pyparsing >= 2
     python-openstackclient >= 5.2.1
     pyyaml >= 5.1
     qemu.qmp >= 0.0.3


### PR DESCRIPTION
requiring pyparsing < 3 is kind of incompatible with current google-api-python-client versions which require httplib2 which requires pyparsing > 3 in recent versions.